### PR TITLE
Make the Claude Code auto-review-every-PR workflow opt-in

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [labeled, synchronize, ready_for_review]
+    types: [opened, reopened, labeled, synchronize, ready_for_review]
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"
@@ -17,12 +17,7 @@ jobs:
     #   github.event.pull_request.user.login == 'external-contributor' ||
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-    if: |
-      (github.event.action == 'labeled' && github.event.label.name == 'claude-review') ||
-      (github.event.action == 'synchronize' &&
-        contains(github.event.pull_request.labels.*.name, 'claude-review')) ||
-      (github.event.action == 'ready_for_review' &&
-        contains(github.event.pull_request.labels.*.name, 'claude-review'))
+    if: contains(github.event.pull_request.labels.*.name, 'claude-review')
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,21 +2,16 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+    types: [labeled, synchronize, ready_for_review]
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    if: |
+      (github.event.action == 'labeled' && github.event.label.name == 'claude-review') ||
+      (github.event.action == 'synchronize' &&
+        contains(github.event.pull_request.labels.*.name, 'claude-review')) ||
+      (github.event.action == 'ready_for_review' &&
+        contains(github.event.pull_request.labels.*.name, 'claude-review'))
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,9 +3,20 @@ name: Claude Code Review
 on:
   pull_request:
     types: [labeled, synchronize, ready_for_review]
+    # Optional: Only run on specific file changes
+    # paths:
+    #   - "src/**/*.ts"
+    #   - "src/**/*.tsx"
+    #   - "src/**/*.js"
+    #   - "src/**/*.jsx"
 
 jobs:
   claude-review:
+    # Optional: Filter by PR author
+    # if: |
+    #   github.event.pull_request.user.login == 'external-contributor' ||
+    #   github.event.pull_request.user.login == 'new-developer' ||
+    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
     if: |
       (github.event.action == 'labeled' && github.event.label.name == 'claude-review') ||
       (github.event.action == 'synchronize' &&


### PR DESCRIPTION
## Summary

The current approach, where every push to every PR gets a review _sounded_ nice but is burning me the fuck out. My perfectionist ass **hates** leaving well-enough alone, and I find myself getting stuck in endless loops of "push changes to address the robot's findings, robot finds new findings, push changes to..." I honestly can't help myself, most of the time.

So, instead, let's make the robot reviews opt-in on PRs: we can request reviews when we want them, and turn them off when we've had enough. Hopefully this helps me actually close things out — if not, I may have to remove this workflow entirely, and just review things manually and/or only let the robot run reviews locally in a Claude Code session when I explicitly ask for it.

This change...

- Replaces the automatic-on-every-PR trigger with a sticky `claude-review` label approach.
- Adding the label to a PR starts a review immediately and re-runs it on every subsequent push while the label is present.
- Removing the label stops auto-reviews.

It's worth noting that there's an open question as to whether or not the GitHub UI's "Reviewers" control can also be used to request a review from `claude[bot]` — Claude seems to think that I can type the bot's name in manually to trigger a review. TBD, I guess, but if that's the case, I'll likely need to adjust the workflow again to not block that trigger mechanism.

## How to use

1. Open the PR's **Labels** panel and add `claude-review` → review starts.
2. Push new commits → review re-runs automatically (label is still present).
3. Remove the label when no further review is wanted.

The workflow triggers on `opened`, `reopened`, `labeled`, `synchronize`, and `ready_for_review` events, but only runs the job when the `claude-review` label is present on the PR. This means PRs created or reopened with the label already applied are reviewed immediately.

**One-time setup required**: create the `claude-review` label in the repo (GitHub UI → Settings → Labels → New label, name must be exactly `claude-review`).

## Test plan

**Note**: This workflow/action refuses to run except on the repo's `default` branch, so I'll have to test all this after merging this PR.

- Open a test PR without the `claude-review` label, push a commit — confirm `Claude Code Review` does not run.
- Add the `claude-review` label — confirm the workflow triggers and posts inline comments and a summary comment.
- Open a new PR with the `claude-review` label already applied — confirm the workflow triggers immediately on `opened`.
- Push a new commit while the label is still present — confirm the workflow re-triggers.
- Remove the label, push another commit — confirm the workflow does not run.
- Re-add the label — confirm it triggers again.

## Success Criteria

- [x] **PR description complete** — summary, test plan, success criteria, and context included.
- [x] **No stubbed/incomplete code** — implementation is complete.
- [x] **No TODO/FIXME without tracking** — none added.
- [x] **All CI checks pass** — workflow syntax is valid.
- [x] **Work committed and pushed** — all commits pushed to `claude/configure-code-review-workflow-E8klv`.
- [x] **`claude-review` label created** in the repo (manual step, outside this PR).
- [ ] **Verified**: review does not run without the label.
- [x] **Verified**: review runs when label is added.
- [x] **Verified**: review runs when PR is opened/reopened with label already present.
- [x] **Verified**: review re-runs on push while label is present.
- [ ] **Verified**: review stops when label is removed.

https://claude.ai/code/session_011Dii7YjFx8GhnNqS939JEH