### PR TITLE
docs: expand and clarify markdown style guide

### DIFF
--- a/.claude/rules/markdown-style.md
+++ b/.claude/rules/markdown-style.md
@@ -18,7 +18,7 @@ There should never be more than one blank line before or after headers;
 ## Line Structure
 
 - One sentence per line for better version control.
-- 110-character line wrap limit at natural break points,
+- 110-character line wrap limit at natural breakpoints,
     such as after punctuation like commas, colons, semicolons,
     and also at the start of new clauses/sentence parts.
   - Lines _can_ optionally be wrapped more aggressively than that at natural breakpoints,

--- a/.claude/rules/markdown-style.md
+++ b/.claude/rules/markdown-style.md
@@ -11,7 +11,7 @@ Every header should have one blank line above it,
   except for headers at the start of a file,
   which should not have any blank lines above them.
 
-There should never be more than one blank line preceding or trailing headers;
+There should never be more than one blank line before or after headers;
   normalize multiple line breaks right before and after headers
   to a single blank line.
 

--- a/.claude/rules/markdown-style.md
+++ b/.claude/rules/markdown-style.md
@@ -1,27 +1,49 @@
 # Markdown Style
 
 All markdown files follow standardized formatting rules.
+These rules are intended to strike a balance
+  where content is easy to read and edit in code editors
+  and where `diff` output for long sections of prose is cleaner.
+
+## Headers and Sections
+
+Every header should have one blank line above it,
+  except for headers at the start of a file,
+  which should not have any blank lines above them.
+
+There should never be more than one blank line preceding or trailing headers;
+  normalize multiple line breaks right before and after headers
+  to a single blank line.
 
 ## Line Structure
 
 - One sentence per line for better version control.
-- 110-character line wrap limit at natural break points.
+- 110-character line wrap limit at natural break points,
+    such as after punctuation like commas, colons, semi-colons,
+    and also at the start of new clauses/sentence parts.
+  - Lines _can_ optionally be wrapped more aggressively than that at natural breakpoints,
+      even when not needed to avoid exceeding the length limit,
+      but care should be taken to try and balance out
+      the length of the lines in each block/paragraph.
 - Meet the line length limit with whitespace changes only
     (line breaks and continuation indentation);
     never alter content to shorten a line.
 - Some elements will consistently exceed the limit and that's fine,
     e.g., URLs, Markdown links, Markdown table rows,
     and reference-style link definitions.
-- POSIX line endings.
-- Trailing whitespace removal (except when required by Markdown).
+- Always use POSIX line endings.
+- Remove any trailing whitespace, except:
+	- Don't remove trailing whitespace that is required by Markdown.
+	- Every file should end with a blank line.
 
 ## Continuation Indentation
 
-Indent wrapped lines 2 spaces past where text begins (count prefix chars + 2):
-
-- Regular prose: 2 spaces (no prefix, text at column 1, indent to column 3).
-- List items (`- ` = 2 chars, text at column 3): 4 spaces (indent to column 5).
-- Checklist items (`- [ ] ` = 6 chars, text at column 7): 8 spaces (indent to column 9).
+All sentences within a block should start at the same column.
+All lines wrapped _within_ a sentence
+  should be indented 2 characters past the sentence start's column.
+List item and task checkbox decorations
+  indent the start of sentences and any wrapped lines
+  one space more than the decorations.
 
 ## Punctuation
 
@@ -37,28 +59,37 @@ End all sentence-like lines with periods, including:
 
 Wrapping regular prose (2 spaces):
 
-```
-The quick brown fox
-  jumped over the lazy dog.
-```
-
-Wrapping list items (4 spaces — aligning with text after `- `):
-
-```
-- The quick brown fox
-    jumped over the lazy dog.
+```markdown
+Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+  sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+Excepteur sint occaecat cupidatat non proident,
+  sunt in culpa qui officia deserunt mollit anim id est laborum.
 ```
 
-Wrapping checklist items (8 spaces — 2 past text start):
+Wrapping sentences in list items:
+
+```markdown
+- Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+    sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+  Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+```
+
+Wrapping sentences in checklist items:
+
+```markdown
+- [ ] Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+        sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+      Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi
+        ut aliquip ex ea commodo consequat.
+```
+
+Visual guide for checklist indentation within a sentence:
 
 ```
-- [ ] The quick brown fox
-        jumped over the lazy dog.
-```
-
-Visual guide for checklist indentation:
-
-```
-- [ ] Text starts here at column 7
-12345678^ (8 spaces — 2 past where text starts)
+- [ ] Text starts here at column 7,
+        and at column 9, here.
+        ^
+        8 spaces before the start of the wrapped line; 2 past the start of its sentence.
 ```

--- a/.claude/rules/markdown-style.md
+++ b/.claude/rules/markdown-style.md
@@ -32,9 +32,8 @@ There should never be more than one blank line preceding or trailing headers;
     e.g., URLs, Markdown links, Markdown table rows,
     and reference-style link definitions.
 - Always use POSIX line endings.
-- Remove any trailing whitespace, except:
-	- Don't remove trailing whitespace that is required by Markdown.
-	- Every file should end with a blank line.
+- Remove trailing whitespace, except where required by Markdown.
+- Always end files with a trailing newline.
 
 ## Continuation Indentation
 

--- a/.claude/rules/markdown-style.md
+++ b/.claude/rules/markdown-style.md
@@ -39,7 +39,7 @@ There should never be more than one blank line preceding or trailing headers;
 
 All sentences within a block should start at the same column.
 All lines wrapped _within_ a sentence
-  should be indented 2 characters past the sentence start's column.
+  should be indented 2 spaces past the sentence start's column.
 List item and task checkbox decorations set the sentence start column:
   sentences start one space past the end of the decoration.
 Continuation lines within those sentences follow the same

--- a/.claude/rules/markdown-style.md
+++ b/.claude/rules/markdown-style.md
@@ -42,9 +42,8 @@ All lines wrapped _within_ a sentence
   should be indented 2 spaces past the sentence start's column.
 List item and task checkbox decorations set the sentence start column:
   sentences start one space past the end of the decoration.
-Continuation lines within those sentences follow the same
-  "indented two spaces past the start of the sentence"
-  rule as all sentences.
+Continuation lines within those sentences follow the same rule as all sentences:
+  they should be indented 2 spaces past the sentence start's column.
 
 ## Punctuation
 

--- a/.claude/rules/markdown-style.md
+++ b/.claude/rules/markdown-style.md
@@ -12,7 +12,7 @@ Every header should have one blank line above it,
   which should not have any blank lines above them.
 
 There should never be more than one blank line before or after headers;
-  normalize multiple line breaks right before and after headers
+  normalize multiple blank lines right before and after headers
   to a single blank line.
 
 ## Line Structure

--- a/.claude/rules/markdown-style.md
+++ b/.claude/rules/markdown-style.md
@@ -40,9 +40,11 @@ There should never be more than one blank line preceding or trailing headers;
 All sentences within a block should start at the same column.
 All lines wrapped _within_ a sentence
   should be indented 2 characters past the sentence start's column.
-List item and task checkbox decorations
-  indent the start of sentences and any wrapped lines
-  one space more than the decorations.
+List item and task checkbox decorations set the sentence start column:
+  sentences start one space past the end of the decoration.
+Continuation lines within those sentences follow the same
+  "indented two spaces past the start of the sentence"
+  rule as all sentences.
 
 ## Punctuation
 

--- a/.claude/rules/markdown-style.md
+++ b/.claude/rules/markdown-style.md
@@ -19,7 +19,7 @@ There should never be more than one blank line preceding or trailing headers;
 
 - One sentence per line for better version control.
 - 110-character line wrap limit at natural break points,
-    such as after punctuation like commas, colons, semi-colons,
+    such as after punctuation like commas, colons, semicolons,
     and also at the start of new clauses/sentence parts.
   - Lines _can_ optionally be wrapped more aggressively than that at natural breakpoints,
       even when not needed to avoid exceeding the length limit,


### PR DESCRIPTION
## Summary

Make the Markdown formatting rules clearer.

- Added a Headers and Sections section with blank-line rules around headers.
- Expanded line-wrap rules with specific natural break points and optional aggressive wrapping.
- Rewrote Continuation Indentation section using sentence-start-column framing for clarity.
- Updated code examples to use lorem ipsum text and added `markdown` language fences.

## Test Plan

- [x] Markdown formatting follows the updated rules described in the file itself.
- [x] No CI failures (docs-only change; no code affected).

## Success Criteria

- [x] PR description complete — summary, test plan, success criteria, and context included.
- [x] No stubbed/incomplete code — this is a docs-only change.
- [x] No TODO/FIXME without tracking.
- [x] All CI checks pass.
- [x] Work committed and pushed.