### PR TITLE
chore: ignore Claude Code worktrees in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ Thumbs.db
 .mise.lock
 
 # Git worktrees
-.worktrees/
+.claude/worktrees/
 
 # Language-specific patterns added per sub-project
 


### PR DESCRIPTION
## Summary

Keep `git status` clean for contributors using Claude Code, by ignoring the `.claude/worktrees/` directory it creates by default for `--worktree` / `EnterWorktree` / agent-isolation sessions.

- Add `.claude/worktrees/` to `.gitignore`.
- Remove the unused `.worktrees/` entry, which no tool (`git`, `gh`, VS Code's built-in worktree support, or Xcode) uses by default, so it isn't needed.

## Design Process

N/A — single-line `.gitignore` tweak; no design docs apply.

## Success Criteria

- [x] All CI checks pass: tests pass, linting succeeds, formatting correct.
- [x] Code review recommendations addressed: all review feedback implemented.
- [x] No stubbed/incomplete code: all implementations are complete and tested.
- [x] No TODO/FIXME without tracking: all TODOs tracked in GitHub issues with references.
- [x] Deferred work tracked in GitHub issues: any deferred work captured with clear acceptance criteria.
- [x] Follows Engineering Principles: code adheres to all `design/engineering-principles/` or has documented divergences.

## Test Plan

- `git status` no longer reports `.claude/worktrees/` as untracked.
- `git check-ignore -v .claude/worktrees/` reports the new rule.
- `git check-ignore -v .worktrees/` reports no match (entry removed cleanly).

## Context

Surfaced while working in this repo: the local `.claude/worktrees/` directory (created by Claude Code when entering a worktree session) was showing as untracked. The previously-ignored `.worktrees/` path is unused and was added defensively before Claude Code adopted its current default.