### PR TITLE
docs: add merging-PRs guidance to PR workflow

### DIFF
--- a/.claude/rules/pr-workflow.md
+++ b/.claude/rules/pr-workflow.md
@@ -23,8 +23,61 @@ This repository uses a **PR-based workflow** with branch protection rules enforc
 3. Push branch: `git push -u origin feature/your-feature-name`.
 4. Create PR: `gh pr create --title "Title" --body "Description"`.
 5. Review and approve PR (self-review is acceptable, particularly for small changes).
-6. Merge PR: `gh pr merge --squash` or `gh pr merge --merge`.
+6. Merge the PR — squash by default; see [Merging PRs](#merging-prs) below
+     for the commit-message convention and exact `gh` invocation.
 7. Branches are automatically deleted after merge (GitHub setting).
+
+## Merging PRs
+
+Default to **squash merges** to keep `main`'s history linear and easy to scan.
+The squashed commit lives in `git log` forever, so invest in writing a good message.
+
+### Commit Message
+
+- **Subject**: `<type>: <description> (#<PR-number>)`.
+  Use the same `<type>:` prefixes as recent history
+    (e.g. `docs:`, `fix:`, `chore:`, `ci:`, `feat:`, `refactor:`).
+  GitHub does not append `(#<PR-number>)` automatically when `--subject` is supplied,
+    so include it manually for traceability back to the PR.
+- **Body**: copy the **Summary** and **Context** sections of the PR description verbatim,
+    separated by a blank line.
+  These two sections explain _what_ changed and _why_,
+    and are the most useful parts for a future reader of `git log` or `git blame`.
+  Drop the `## Summary` / `## Context` headers if the prose reads naturally without them.
+
+### Command
+
+Pass `--subject` and `--body` explicitly
+  so the merge commit is composed deliberately
+  rather than inheriting the entire PR description (success-criteria checklist included):
+
+```bash
+gh pr merge <PR#> --squash --delete-branch \
+  --subject "<type>: <description> (#<PR#>)" \
+  --body "$(cat <<'EOF'
+<Summary section text>
+
+<Context section text>
+EOF
+)"
+```
+
+`--delete-branch` removes the remote branch after merging
+  and switches the local checkout back to `main`,
+  also deleting the merged local branch.
+
+### Other Merge Strategies
+
+- `--merge` (true merge commit) is acceptable
+    when preserving individual commits has value
+    — e.g. a series of independent commits that each stand on their own
+    and are worth keeping in history separately.
+- `--rebase` is generally avoided in this repo.
+
+### Bypassing Review
+
+Use `--admin` only when bypassing review has been explicitly authorized
+  (e.g. trivial changes the author has confirmed, or hotfixes).
 
 ## PR Requirements
 


### PR DESCRIPTION
## Summary

Codify how PRs in this repo should be merged so the squashed commit on `main` stays useful in `git log` / `git blame`. This was prompted by merging #11 with `gh pr merge --squash --admin --subject "..."` and noticing the `(#11)` suffix that prior merges had was missing — `gh` doesn't auto-append the PR number when `--subject` is supplied, and there were no written conventions for what should go in the squash commit either.

- Add a new **Merging PRs** section to `.claude/rules/pr-workflow.md`.
- Default to squash merges.
- Subject format: `<type>: <description> (#<PR-number>)` with the suffix added manually.
- Body: copy the **Summary** and **Context** sections of the PR description verbatim (drop the headers if the prose reads naturally without them).
- Provide a concrete `gh pr merge --squash --delete-branch` invocation using `--subject` / `--body`.
- Note when `--merge`, `--rebase`, and `--admin` are appropriate.

Updates step 6 of the existing **Workflow Using gh CLI** numbered list to forward-reference the new section.

## Design Process

N/A — convention update; no design docs apply.

## Success Criteria

- [x] All CI checks pass: tests pass, linting succeeds, formatting correct.
- [x] Code review recommendations addressed: all review feedback implemented.
- [x] No stubbed/incomplete code: all implementations are complete and tested.
- [x] No TODO/FIXME without tracking: all TODOs tracked in GitHub issues with references.
- [x] Deferred work tracked in GitHub issues: any deferred work captured with clear acceptance criteria.
- [x] Follows Engineering Principles: code adheres to all `design/engineering-principles/` or has documented divergences.
- [x] Markdown formatting follows project guidelines (one sentence per line, 110-char wrap, continuation indent rules).
- [x] All links verified working (the new `#merging-prs` anchor links from step 6).
- [x] Spelling and grammar checked.

## Test Plan

- Manual review of the rendered file in GitHub's Markdown preview.
- `awk '{ if (length > 110) print NR }' .claude/rules/pr-workflow.md` — no lines exceed the 110-char wrap limit.
- Cross-check that the **Summary** and **Context** section names match what is defined in the existing **Description Outline** subsection further down in the same file.

## Context

After merging #11 (`chore: gitignore .claude/worktrees/, drop unused .worktrees/`), the resulting squash commit on `main` lacked the `(#N)` suffix that prior merges (#7-#10) all had. Investigation showed this is `gh`'s behavior when `--subject` is supplied — it takes the override literally and skips the PR-number appendage that would otherwise come from the PR title. Without written conventions, this footgun would keep recurring. This PR closes the gap by making the convention explicit and giving a copy-pasteable command.