### PR TITLE
docs: add macOS Focus Gopher design and supporting analyses

### DIFF
--- a/.claude/rules/engineering-principles.md
+++ b/.claude/rules/engineering-principles.md
@@ -18,6 +18,10 @@ During design discussions, watch for generalizable patterns that could become
   Model all errors explicitly; never suppress error information.
 - [Fail Fast and Loud](/design/engineering-principles/2026-01-09-fail-fast.md):
   Crash immediately on impossible states with clear messages.
+- [Least Privilege](/design/engineering-principles/2026-05-12-least-privilege.md):
+  Grant the narrowest capability that does the job; broker privileged access, especially for agents.
+- [Clear, Unambiguous, Easily-Parsed Data Models](/design/engineering-principles/2026-05-12-clear-data-models.md):
+  Separate orthogonal facts; never collapse "failed" into "negative result".
 
 ### Testing Principles
 

--- a/design/analyses/2026-05-12-focus-state-json-shape.md
+++ b/design/analyses/2026-05-12-focus-state-json-shape.md
@@ -62,10 +62,46 @@ No. That principle is about *separating orthogonal facts into their own fields* 
   Nesting those same facts under `focus`/`meta` would not make them any more orthogonal; it would just
   add a level of indirection that every consumer (and every `jq`/`grep` one-liner) has to walk through.
 
+### When nesting *does* earn its keep: making invalid states unrepresentable
+
+The strongest argument for grouping fields is not aesthetics or extensibility — it is *making invalid
+  states unrepresentable*. When several fields are conceptually one unit that must vary together (the
+  classic example: `x`, `y`, `z` that are always all-`Some` or all-`None`, far better modeled as one
+  `position: Option<Coordinates>` than three independent `Option`s), grouping them turns "every
+  consumer must remember to check the combination" into "the type system checks it for you." This is
+  exactly the [Strong Typing and Information
+  Preservation](../engineering-principles/2026-01-07-strong-typing.md) principle.
+
+`FocusState` *does* have such a unit: when `ok` is `false`, `focus_enabled` and `focus_name` are
+  meaningless; when `focus_enabled` is `false`, `focus_name` is meaningless. A flat wire object can
+  literally represent the nonsense `{"ok": false, "focus_enabled": true, …}`. So this is a real
+  consideration here, not a strawman — and it is resolved by splitting the question in two:
+
+- **The helper's *internal* model is a sum type, where the invalid states are unrepresentable.**
+    The Rust side is modeled as roughly `enum FocusState { Determined { focus: Option<FocusInfo>,
+    macos: MacosCompat }, Failed { error: ErrorCode, macos: MacosCompat } }` (with
+    `FocusInfo { name: Option<String> }`) — there is no way to construct "failed but Focus on", or "no
+    Focus but here's its name". This is where the strong-typing win is captured, in the code that
+    actually branches on it.
+- **The *wire* form is a flat, schema-validated projection of that sum type.** JSON has no native sum
+    types; any consumer — `jq`, a shell `case`, a five-line Python script — branches on a discriminant
+    regardless of whether the bytes are flat or nested. A nested `{"focus": {...}|null, "meta": {...}}`
+    does not make the wire format self-checking; the consumer still has to know the `ok`/`error` rule.
+    What actually constrains the valid combinations on the wire is the **published JSON Schema**
+    (conditional `required`/`oneOf` on `ok`), which both flat and nested forms need equally. Given
+    that, the flat projection keeps the ergonomics (shallow paths, trivial `jq`) without giving up any
+    enforceable guarantee the nested form would have provided.
+
+In short: capture the "illegal states unrepresentable" guarantee in the strongly-typed *internal*
+  model (where it has teeth), and let the *wire* contract be the flat projection plus its schema.
+
 ## Recommendation
 
-- **Keep `FocusState` flat.** It is one small, fixed-schema response; flat well-named orthogonal fields
-    are the easiest to read, parse, and document, and that is what comparable well-regarded APIs do.
+- **Keep `FocusState` flat *on the wire*, backed by a strongly-typed internal sum type.** It is one
+    small, fixed-schema response; flat well-named orthogonal fields are the easiest to read, parse, and
+    document, and that is what comparable well-regarded APIs do. The "make invalid states
+    unrepresentable" guarantee is captured in the helper's internal model and enforced on the wire by
+    the published JSON Schema, not by nesting.
 - **The CLI wrapper exits non-zero when `ok` is `false`** (and zero otherwise), so shell scripts can
     branch on the exit code without parsing JSON; the JSON body still carries `ok` and `error` for
     programmatic consumers reading the socket directly. This gives us the "proper status channel *and*
@@ -78,7 +114,8 @@ No. That principle is about *separating orthogonal facts into their own fields* 
 
 - **Product Requirement**: [macOS Focus Gopher](../product-requirements/2026-05-12-macos-focus-gopher.md).
 - **Engineering Design**: [macOS Focus Gopher Engineering Design](../engineering-designs/2026-05-12-macos-focus-gopher.md).
-- **Engineering Principle**: [Clear, Unambiguous, Easily-Parsed Data Models](../engineering-principles/2026-05-12-clear-data-models.md).
+- **Engineering Principles**: [Clear, Unambiguous, Easily-Parsed Data Models](../engineering-principles/2026-05-12-clear-data-models.md);
+    [Strong Typing and Information Preservation](../engineering-principles/2026-01-07-strong-typing.md).
 - Sources:
   - [Vinay Sahni — Best Practices for Designing a Pragmatic RESTful API](https://www.vinaysahni.com/best-practices-for-a-pragmatic-restful-api).
   - [On shapes, sizes and envelopes (REST API ones) — fleetster Tech Blog](https://medium.com/fleetster-tech-blog/on-shapes-sizes-and-envelopes-rest-api-ones-272549d17108).

--- a/design/analyses/2026-05-12-focus-state-json-shape.md
+++ b/design/analyses/2026-05-12-focus-state-json-shape.md
@@ -145,21 +145,26 @@ This is *not* collapsing a positive result into a failure (which our
 { "macos_version": "15.5", "macos_compatibility": "supported",
   "determined": { "focus_off": {} } }
 
-// (c) determined on an unknown-but-working macOS version
-{ "macos_version": "26.0", "macos_compatibility": "unknown_but_working",
-  "message": "Focus parsing appears to work, but this macOS version is not on the known-supported list. Please submit an issue or PR marking macOS 26.0 as compatible if this looks right.",
+// (c) determined on an unknown (unlisted) macOS version — the unknown variant carries the report message
+{ "macos_version": "26.0",
+  "macos_compatibility": { "unknown": { "message": "macOS 26.0 is not on the known-supported list. Please file an issue or PR reporting whether Focus parsing works here, so it can be added." } },
   "determined": { "focus_on": { "name": "Do Not Disturb" } } }
 
-// (d) failure (here: an active Focus whose name could not be resolved)
-{ "macos_version": "26.0", "macos_compatibility": "unknown",
-  "message": "A Focus appears active but its name could not be resolved. Please file an issue or PR with your macOS version, helper version, and this error code.",
-  "failed": { "error": "focus_name_unresolved" } }
+// (d) failure — the failed variant carries the guidance message (here, FDA remediation)
+{ "macos_version": "15.5", "macos_compatibility": "supported",
+  "failed": { "error": "focus_permission_denied",
+    "message": "Full Disk Access is required. Grant it to /Applications/FocusGopher.app under System Settings > Privacy & Security > Full Disk Access, then retry." } }
 ```
 
 - **`focus_on` always carries a real `name`**; an active Focus whose name cannot be resolved is a
     `failed` with `focus_name_unresolved`, not a partial success (see above).
-- **Shared metadata stays at the top level** (`macos_version`, `macos_compatibility`, and an optional
-    `message`, omitted when there is none), since it is reported on both success and failure.
+- **Shared metadata stays at the top level** (`macos_version` and `macos_compatibility`), since it is
+    reported on both success and failure. **Human-readable guidance lives *inside the variant that owns
+    it*** — a `message` on the `macos_compatibility` `unknown` variant (report whether this version
+    works) and a `message` on the `failed` variant (what went wrong / how to fix or report) — rather
+    than as a single overloaded, free-floating top-level field. Because the CLI prints the raw JSON, the
+    text must travel on the wire; attaching each message to its triggering variant keeps it
+    single-purpose and means it can't appear without its condition.
 - **The CLI wrapper exits non-zero when the outcome is `failed`** (and zero otherwise), so shell
     scripts can branch on the exit code without parsing JSON.
 - **No `data`/`meta` envelope and no `errors` array** — YAGNI; `get_focus()` either determines the

--- a/design/analyses/2026-05-12-focus-state-json-shape.md
+++ b/design/analyses/2026-05-12-focus-state-json-shape.md
@@ -1,0 +1,87 @@
+# `FocusState` JSON Response Shape: Flat vs. Nested
+
+## Question
+
+The [macOS Focus Gopher](../engineering-designs/2026-05-12-macos-focus-gopher.md) returns a single
+  `FocusState` object from its one operation, `get_focus()`, over a local socket (and, via a thin CLI
+  wrapper, as JSON on stdout).
+Should that object be **flat** —
+
+```json
+{"ok": true, "focus_enabled": true, "focus_name": "Sleep",
+ "macos_version": "15.5", "macos_compatibility": "supported", "message": null}
+```
+
+— or **nested**, grouping the "answer" and the "metadata" —
+
+```json
+{"focus": {"enabled": true, "name": "Sleep"},
+ "meta": {"ok": true, "errors": null, "macos_compatibility": {"macos_version": "15.5", "rating": "supported"}}}
+```
+
+This came up in PR review (does having `ok` and `error` as flat siblings, alongside the focus fields,
+  risk *immediately* violating our new "clear, unambiguous, easily-parsed data models" principle?),
+  with a request to look at how popular, battle-tested, well-regarded simple JSON APIs do it.
+
+## Findings
+
+### What the API-design literature says
+
+- **Envelopes (`{"data": …, "meta": …}`) earn their keep mainly for *collections* and *pagination*** —
+    you should never return a bare JSON array at the top level, and an envelope gives you somewhere to
+    hang `next`/`total`/`links`. For a *single* small object there is much less to gain, and most
+    guidance says return the object at the top level rather than wrapping it.
+- **The "`200 OK` with `success: false` in the body" complaint is specifically about HTTP** — it's bad
+    because it *shadows the HTTP status code*, forcing clients to parse the body to detect failure and
+    muddying monitoring. Our transport is a Unix domain socket plus a CLI printing JSON; there is no
+    HTTP status code for a body-level `ok` to shadow. The recommended pattern there is "use the proper
+    status channel *and* put details in the body" — which, translated to our world, is "the CLI exits
+    non-zero on failure *and* the JSON carries `ok`/`error`".
+- **The dominant value cited for envelopes is future extensibility** (you can add `meta` later without
+    breaking the contract). For a fixed, single-operation contract that we publish as a JSON Schema,
+    that argument is weak — there is nothing planned to extend, and a second operation would be its own
+    schema anyway. Adding structure now for hypothetical future structure is a YAGNI violation.
+- **Consistency matters more than flat-vs-nested in the abstract.** With exactly one operation and one
+    response shape, there is no consistency tension to resolve.
+
+### What well-regarded simple JSON APIs actually do
+
+Single-resource responses in widely-used, well-liked APIs are overwhelmingly *flat at the top level*:
+  Stripe returns flat objects (with an `object` type discriminator), GitHub returns flat resources, and
+  most "GET one thing" endpoints return the thing's fields directly rather than wrapping a lone resource
+  in `{"data": {...}}`. The `{"data": ..., "meta": ...}` / JSON:API style shows up around *collections*
+  and pagination, not around a single small object.
+
+### Does flat conflict with the "clear data models" principle?
+
+No. That principle is about *separating orthogonal facts into their own fields* and *never collapsing
+  distinct states into one ambiguous value* — it is agnostic about nesting. `FocusState` already does
+  this: `ok` (did we determine the state?), `focus_enabled` (is a Focus on?), `focus_name` (do we have
+  a name?), and `macos_compatibility` (is this OS version supported?) are four distinct, well-named
+  fields, and a parse failure is `ok: false` with an `error` code, never `focus_enabled: false`.
+  Nesting those same facts under `focus`/`meta` would not make them any more orthogonal; it would just
+  add a level of indirection that every consumer (and every `jq`/`grep` one-liner) has to walk through.
+
+## Recommendation
+
+- **Keep `FocusState` flat.** It is one small, fixed-schema response; flat well-named orthogonal fields
+    are the easiest to read, parse, and document, and that is what comparable well-regarded APIs do.
+- **The CLI wrapper exits non-zero when `ok` is `false`** (and zero otherwise), so shell scripts can
+    branch on the exit code without parsing JSON; the JSON body still carries `ok` and `error` for
+    programmatic consumers reading the socket directly. This gives us the "proper status channel *and*
+    details in the body" pattern without an envelope.
+- **Do not add a `meta` block, an `errors` array, or a nested `macos_compatibility` object** unless a
+    concrete consumer need appears — and `errors` plural in particular is unnecessary: `get_focus()`
+    either determines the state or hits exactly one failure, so a single `error` code suffices.
+
+## References
+
+- **Product Requirement**: [macOS Focus Gopher](../product-requirements/2026-05-12-macos-focus-gopher.md).
+- **Engineering Design**: [macOS Focus Gopher Engineering Design](../engineering-designs/2026-05-12-macos-focus-gopher.md).
+- **Engineering Principle**: [Clear, Unambiguous, Easily-Parsed Data Models](../engineering-principles/2026-05-12-clear-data-models.md).
+- Sources:
+  - [Vinay Sahni — Best Practices for Designing a Pragmatic RESTful API](https://www.vinaysahni.com/best-practices-for-a-pragmatic-restful-api).
+  - [On shapes, sizes and envelopes (REST API ones) — fleetster Tech Blog](https://medium.com/fleetster-tech-blog/on-shapes-sizes-and-envelopes-rest-api-ones-272549d17108).
+  - [Flat vs Nested REST Endpoints: Why Error Clarity Favors Flat Design](https://medium.com/@kh.taheri/flat-vs-nested-rest-endpoints-why-error-clarity-favors-flat-design-599e77054fa3).
+  - [Speakeasy — Responses Best Practices in REST API Design](https://www.speakeasy.com/api-design/responses).
+  - [Guidelines on JSON responses for RESTful services](https://medium.com/@sunitparekh/guidelines-on-json-responses-for-restful-services-1ba7c0c015d).

--- a/design/analyses/2026-05-12-focus-state-json-shape.md
+++ b/design/analyses/2026-05-12-focus-state-json-shape.md
@@ -1,119 +1,169 @@
-# `FocusState` JSON Response Shape: Flat vs. Nested
+# `FocusState` JSON Response Shape: Flat vs. Tagged Union
 
 ## Question
 
 The [macOS Focus Gopher](../engineering-designs/2026-05-12-macos-focus-gopher.md) returns a single
   `FocusState` object from its one operation, `get_focus()`, over a local socket (and, via a thin CLI
   wrapper, as JSON on stdout).
-Should that object be **flat** —
+The response is conceptually a *sum type*: either the helper **determined** the state (a Focus is on,
+  with its name, or no Focus is on) or it **failed** (with an error code), plus a little shared metadata.
+Should the wire form be a **flat object of nullable siblings** —
 
 ```json
 {"ok": true, "focus_enabled": true, "focus_name": "Sleep",
  "macos_version": "15.5", "macos_compatibility": "supported", "message": null}
 ```
 
-— or **nested**, grouping the "answer" and the "metadata" —
+— or a **tagged discriminated union** that mirrors the sum type —
 
 ```json
-{"focus": {"enabled": true, "name": "Sleep"},
- "meta": {"ok": true, "errors": null, "macos_compatibility": {"macos_version": "15.5", "rating": "supported"}}}
+{"macos_version": "15.5", "macos_compatibility": "supported",
+ "determined": {"focus_on": {"name": "Sleep"}}}
 ```
 
 This came up in PR review (does having `ok` and `error` as flat siblings, alongside the focus fields,
-  risk *immediately* violating our new "clear, unambiguous, easily-parsed data models" principle?),
-  with a request to look at how popular, battle-tested, well-regarded simple JSON APIs do it.
+  risk *immediately* violating our new "clear, unambiguous, easily-parsed data models" principle?).
+This analysis initially landed on **flat**; a deeper survey then reversed that to a **tagged union**.
+It records the final decision and the reasoning, including why the first pass was wrong.
 
 ## Findings
 
-### What the API-design literature says
+### Two different questions, often conflated
 
-- **Envelopes (`{"data": …, "meta": …}`) earn their keep mainly for *collections* and *pagination*** —
-    you should never return a bare JSON array at the top level, and an envelope gives you somewhere to
-    hang `next`/`total`/`links`. For a *single* small object there is much less to gain, and most
-    guidance says return the object at the top level rather than wrapping it.
-- **The "`200 OK` with `success: false` in the body" complaint is specifically about HTTP** — it's bad
-    because it *shadows the HTTP status code*, forcing clients to parse the body to detect failure and
-    muddying monitoring. Our transport is a Unix domain socket plus a CLI printing JSON; there is no
-    HTTP status code for a body-level `ok` to shadow. The recommended pattern there is "use the proper
-    status channel *and* put details in the body" — which, translated to our world, is "the CLI exits
-    non-zero on failure *and* the JSON carries `ok`/`error`".
-- **The dominant value cited for envelopes is future extensibility** (you can add `meta` later without
-    breaking the contract). For a fixed, single-operation contract that we publish as a JSON Schema,
-    that argument is weak — there is nothing planned to extend, and a second operation would be its own
-    schema anyway. Adding structure now for hypothetical future structure is a YAGNI violation.
-- **Consistency matters more than flat-vs-nested in the abstract.** With exactly one operation and one
-    response shape, there is no consistency tension to resolve.
+"Nesting" bundles two unrelated decisions that should be judged separately:
 
-### What well-regarded simple JSON APIs actually do
+- A **`data`/`meta` envelope** — about collections, pagination, links, and forward-compatible
+    extensibility. For a *single* small object this buys little, and adding it now for hypothetical
+    future structure is a YAGNI violation. Not what we need.
+- A **discriminated (tagged) union** — about success-vs-error (or variant) *coherence*: making
+    "determined" and "failed" structurally distinct so the incoherent mixes can't occur. This is the
+    axis that actually matters for a single success-XOR-error response.
 
-Single-resource responses in widely-used, well-liked APIs are overwhelmingly *flat at the top level*:
-  Stripe returns flat objects (with an `object` type discriminator), GitHub returns flat resources, and
-  most "GET one thing" endpoints return the thing's fields directly rather than wrapping a lone resource
-  in `{"data": {...}}`. The `{"data": ..., "meta": ...}` / JSON:API style shows up around *collections*
-  and pagination, not around a single small object.
+The first pass conflated the two: it argued (correctly) against an envelope and then carried that
+  conclusion over to the union question, where it does not apply.
 
-### Does flat conflict with the "clear data models" principle?
+### Why the "flat is fine" precedent does not transfer to us
 
-No. That principle is about *separating orthogonal facts into their own fields* and *never collapsing
-  distinct states into one ambiguous value* — it is agnostic about nesting. `FocusState` already does
-  this: `ok` (did we determine the state?), `focus_enabled` (is a Focus on?), `focus_name` (do we have
-  a name?), and `macos_compatibility` (is this OS version supported?) are four distinct, well-named
-  fields, and a parse failure is `ok: false` with an `error` code, never `focus_enabled: false`.
-  Nesting those same facts under `focus`/`meta` would not make them any more orthogonal; it would just
-  add a level of indirection that every consumer (and every `jq`/`grep` one-liner) has to walk through.
+Single-resource responses in big, well-liked REST APIs *are* mostly flat — GitHub, Stripe, Twilio,
+  much of Slack. But they are flat largely because **HTTP status carries the success-vs-error
+  discriminant**: the body does not have to encode coherence because the status code already did. We
+  have **no HTTP layer** — a Unix domain socket plus a CLI printing JSON — so the body must carry the
+  discriminant itself.
 
-### When nesting *does* earn its keep: making invalid states unrepresentable
+The right comparison is systems that pack success-XOR-error into one JSON object with no transport
+  status to lean on, and those do *not* go flat:
 
-The strongest argument for grouping fields is not aesthetics or extensibility — it is *making invalid
-  states unrepresentable*. When several fields are conceptually one unit that must vary together (the
-  classic example: `x`, `y`, `z` that are always all-`Some` or all-`None`, far better modeled as one
-  `position: Option<Coordinates>` than three independent `Option`s), grouping them turns "every
-  consumer must remember to check the combination" into "the type system checks it for you." This is
-  exactly the [Strong Typing and Information
-  Preservation](../engineering-principles/2026-01-07-strong-typing.md) principle.
+- **JSON-RPC 2.0** (and **LSP**, built on it): a Response object MUST contain `result` *or* `error` and
+    **MUST NOT** contain both — a structural discriminated union, not optional sibling fields
+    ([spec](https://www.jsonrpc.org/specification)). This is the closest structural analogue to
+    `get_focus()`.
 
-`FocusState` *does* have such a unit: when `ok` is `false`, `focus_enabled` and `focus_name` are
-  meaningless; when `focus_enabled` is `false`, `focus_name` is meaningless. A flat wire object can
-  literally represent the nonsense `{"ok": false, "focus_enabled": true, …}`. So this is a real
-  consideration here, not a strawman — and it is resolved by splitting the question in two:
+Honest counter-evidence, kept on the record:
 
-- **The helper's *internal* model is a sum type, where the invalid states are unrepresentable.**
-    The Rust side is modeled as roughly `enum FocusState { Determined { focus: Option<FocusInfo>,
-    macos: MacosCompat }, Failed { error: ErrorCode, macos: MacosCompat } }` (with
-    `FocusInfo { name: Option<String> }`) — there is no way to construct "failed but Focus on", or "no
-    Focus but here's its name". This is where the strong-typing win is captured, in the code that
-    actually branches on it.
-- **The *wire* form is a flat, schema-validated projection of that sum type — and the schema itself
-    rejects the incoherent combinations.** JSON Schema can enforce cross-field coherence directly: a
-    `oneOf` over the success/failure variants, `if`/`then` (or `dependentRequired`), and `const`/`enum`
-    on the discriminant let the published schema make `{"ok": false, "focus_enabled": true, …}` *fail
-    validation*, require `error` exactly when `ok` is `false` (and forbid it when `ok` is `true`), and
-    require `focus_name` to be null when `focus_enabled` is false. So the "illegal states" guarantee is
-    enforceable on the wire, not only in the Rust model — and it holds for the **flat** object just as
-    well as for a nested one, so nesting buys no enforcement here. The one thing no schema (flat or
-    nested) can do is force an *ad-hoc consumer that never validates* — a `jq` or shell one-liner — to
-    branch correctly; JSON has no native sum types, so such a reader still keys off the `ok`/`error`
-    discriminant by hand. Net: the JSON Schema protects the contract boundary (producers, conformance
-    tests, validating clients), the internal sum type stops the producer from ever emitting nonsense,
-    and the flat projection keeps shallow paths and trivial `jq` — none of which nesting improves.
+- The **Slack Web API** is essentially our proposed flat shape — top-level `{"ok": false, "error":
+    "..."}`, often returned under HTTP 200, so it is a real flat precedent that does *not* lean on
+    status ([docs.slack.dev](https://docs.slack.dev/apis/web-api/)). But its body is coherent only by
+    convention (nothing stops `{"ok": false, …success fields…}`), it is tuned for a vast
+    dynamically-typed consumer base, and it is not trying to mirror a producer-side sum type — the
+    opposite of our situation.
+- **GraphQL** deliberately allows a *partial* response (`data` *and* `errors` together)
+    ([graphql.org](https://graphql.org/learn/response/)) — a reason to avoid a strict XOR. We have no
+    partial state, so it does not apply.
 
-In short: capture the "illegal states unrepresentable" guarantee in the strongly-typed *internal*
-  model (where it has teeth), and let the *wire* contract be the flat projection plus its schema.
+### Keep the wire aligned with the internal model (serde, Fowler, "parse, don't validate")
+
+The helper is a Rust producer with a real sum type. That makes the alignment argument concrete:
+
+- **serde** offers four enum representations ([serde.rs](https://serde.rs/enum-representations.html)):
+    externally tagged (default), internally tagged, adjacently tagged, and untagged. A flat
+    struct-of-optionals is closest to **untagged**, which the docs flag as the fragile one — variants
+    are told apart only by which optional fields happen to be present. A tagged enum makes **the wire
+    *be* the serialized internal sum type**, removing the hand-maintained flattening layer that can
+    drift out of sync — exactly the cross-layer-divergence bug class to avoid.
+- **Martin Fowler, Local DTO** ([martinfowler.com](https://martinfowler.com/bliki/LocalDTO.html)): he
+    is against reshaping the wire away from the domain model unless there is a "significant mismatch."
+    For a one-call helper there is none, so flattening would be gratuitous divergence, not a feature.
+- **"Parse, don't validate"** (Alexis King,
+    [lexi-lambda](https://lexi-lambda.github.io/blog/2019/11/05/parse-don-t-validate/)): the wire is the
+    boundary; a tagged shape lets each consumer parse straight into its own sum type instead of
+    re-deriving "if not ok, ignore focus_enabled."
+
+### Making invalid states unrepresentable — in code *and* on the wire
+
+The strongest argument for grouping is *making invalid states unrepresentable* — the
+  [Strong Typing and Information Preservation](../engineering-principles/2026-01-07-strong-typing.md)
+  principle. `FocusState` has such a unit: "failed but a Focus is on" and "no Focus but here's its name"
+  are nonsense. With the tagged union, both the internal model and the wire exclude them structurally:
+
+- The **internal Rust model** is a sum type (`Outcome::Determined(Focus)` vs. `Failed { error }`, with
+    `Focus::FocusOn { name }` vs. `FocusOff`), so the bad combinations are unconstructable in code.
+- The **wire** is that sum type's externally-tagged serialization, so the bad combinations are absent
+    on the wire too — and the published **JSON Schema** adds a `oneOf` as belt-and-suspenders. (JSON
+    Schema can express this coherence for *any* representation — flat or tagged — via
+    `oneOf`/`if`-`then`/`const`, so schema power does not decide the shape; what a schema cannot do is
+    force an ad-hoc consumer that never validates to branch correctly, which is an argument for making
+    the structure itself unambiguous.)
+
+### Why "Focus on but no name" is a failure, not a partial success
+
+A tempting fourth state is "a Focus is on, but its identifier could not be mapped to a name." We model
+  this as a **failure** (`focus_name_unresolved`), not a partial success, for three reasons:
+
+- **The name is the primary thing consumers want**; the on/off boolean is secondary. A nameless "Focus
+    is on" does not satisfy the main use case.
+- **It is effectively hypothetical as a steady state.** Names resolve from `ModeConfigurations.json`
+    (user Foci, which must be configured to be active) plus a fixed table for the small set of
+    built-ins; community tools resolve names reliably, and there is no evidence of a real
+    "active-but-permanently-unnameable" Focus. The realistic causes — schema/format drift, a transient
+    mid-write race, or a brand-new built-in identifier on a new macOS version — are all symptoms of a
+    problem (a coverage/parse gap), not a legitimate ongoing state.
+- **YAGNI:** modeling it as a success variant would complicate every consumer's success path for a
+    state we cannot evidence. Reporting it as `failed` with `focus_name_unresolved` (end-to-end, not a
+    CLI-only nicety) keeps the common path simple.
+
+This is *not* collapsing a positive result into a failure (which our
+  [clear-data-models](../engineering-principles/2026-05-12-clear-data-models.md) principle forbids):
+  by the evidence an unnameable active Focus is a symptom of incomplete parsing, not a legitimate
+  positive result, and the dedicated error code keeps the taxonomy clear rather than lossy.
 
 ## Recommendation
 
-- **Keep `FocusState` flat *on the wire*, backed by a strongly-typed internal sum type.** It is one
-    small, fixed-schema response; flat well-named orthogonal fields are the easiest to read, parse, and
-    document, and that is what comparable well-regarded APIs do. The "make invalid states
-    unrepresentable" guarantee is captured in the helper's internal model and enforced on the wire by
-    the published JSON Schema, not by nesting.
-- **The CLI wrapper exits non-zero when `ok` is `false`** (and zero otherwise), so shell scripts can
-    branch on the exit code without parsing JSON; the JSON body still carries `ok` and `error` for
-    programmatic consumers reading the socket directly. This gives us the "proper status channel *and*
-    details in the body" pattern without an envelope.
-- **Do not add a `meta` block, an `errors` array, or a nested `macos_compatibility` object** unless a
-    concrete consumer need appears — and `errors` plural in particular is unnecessary: `get_focus()`
-    either determines the state or hits exactly one failure, so a single `error` code suffices.
+- **Make `FocusState` an externally-tagged discriminated union that mirrors the internal sum type**,
+    not a flat object of nullable siblings. We have no transport status code, so (like JSON-RPC / LSP)
+    the body carries the discriminant; the tagged form keeps the wire aligned with the Rust model (no
+    divergent mapping), makes illegal states unrepresentable on the wire as well as in code, and is
+    obvious to a human without consulting the schema.
+- **Hide Rust's `Result`/`Option` plumbing behind domain-named keys** — `determined`/`failed` and
+    `focus_on`/`focus_off`, never serialized `Ok`/`Err`/`null`. The shapes:
+
+```jsonc
+// (a) determined, Focus on
+{ "macos_version": "15.5", "macos_compatibility": "supported",
+  "determined": { "focus_on": { "name": "Sleep" } } }
+
+// (b) determined, Focus off
+{ "macos_version": "15.5", "macos_compatibility": "supported",
+  "determined": { "focus_off": {} } }
+
+// (c) determined on an unknown-but-working macOS version
+{ "macos_version": "26.0", "macos_compatibility": "unknown_but_working",
+  "message": "Focus parsing appears to work, but this macOS version is not on the known-supported list. Please submit an issue or PR marking macOS 26.0 as compatible if this looks right.",
+  "determined": { "focus_on": { "name": "Do Not Disturb" } } }
+
+// (d) failure (here: an active Focus whose name could not be resolved)
+{ "macos_version": "26.0", "macos_compatibility": "unknown",
+  "message": "A Focus appears active but its name could not be resolved. Please file an issue or PR with your macOS version, helper version, and this error code.",
+  "failed": { "error": "focus_name_unresolved" } }
+```
+
+- **`focus_on` always carries a real `name`**; an active Focus whose name cannot be resolved is a
+    `failed` with `focus_name_unresolved`, not a partial success (see above).
+- **Shared metadata stays at the top level** (`macos_version`, `macos_compatibility`, and an optional
+    `message`, omitted when there is none), since it is reported on both success and failure.
+- **The CLI wrapper exits non-zero when the outcome is `failed`** (and zero otherwise), so shell
+    scripts can branch on the exit code without parsing JSON.
+- **No `data`/`meta` envelope and no `errors` array** — YAGNI; `get_focus()` either determines the
+    state or hits exactly one failure, so a single `error` code suffices.
 
 ## References
 
@@ -122,8 +172,9 @@ In short: capture the "illegal states unrepresentable" guarantee in the strongly
 - **Engineering Principles**: [Clear, Unambiguous, Easily-Parsed Data Models](../engineering-principles/2026-05-12-clear-data-models.md);
     [Strong Typing and Information Preservation](../engineering-principles/2026-01-07-strong-typing.md).
 - Sources:
-  - [Vinay Sahni — Best Practices for Designing a Pragmatic RESTful API](https://www.vinaysahni.com/best-practices-for-a-pragmatic-restful-api).
-  - [On shapes, sizes and envelopes (REST API ones) — fleetster Tech Blog](https://medium.com/fleetster-tech-blog/on-shapes-sizes-and-envelopes-rest-api-ones-272549d17108).
-  - [Flat vs Nested REST Endpoints: Why Error Clarity Favors Flat Design](https://medium.com/@kh.taheri/flat-vs-nested-rest-endpoints-why-error-clarity-favors-flat-design-599e77054fa3).
-  - [Speakeasy — Responses Best Practices in REST API Design](https://www.speakeasy.com/api-design/responses).
-  - [Guidelines on JSON responses for RESTful services](https://medium.com/@sunitparekh/guidelines-on-json-responses-for-restful-services-1ba7c0c015d).
+  - [JSON-RPC 2.0 Specification — `result` XOR `error`](https://www.jsonrpc.org/specification).
+  - [serde — enum representations (externally/internally/adjacently/untagged)](https://serde.rs/enum-representations.html).
+  - [Alexis King — Parse, don't validate](https://lexi-lambda.github.io/blog/2019/11/05/parse-don-t-validate/).
+  - [Martin Fowler — Local DTO](https://martinfowler.com/bliki/LocalDTO.html).
+  - [Slack Web API — top-level `ok`/`error`](https://docs.slack.dev/apis/web-api/).
+  - [GraphQL — response (`data` + `errors`, partial responses)](https://graphql.org/learn/response/).

--- a/design/analyses/2026-05-12-focus-state-json-shape.md
+++ b/design/analyses/2026-05-12-focus-state-json-shape.md
@@ -83,14 +83,19 @@ The strongest argument for grouping fields is not aesthetics or extensibility �
     `FocusInfo { name: Option<String> }`) — there is no way to construct "failed but Focus on", or "no
     Focus but here's its name". This is where the strong-typing win is captured, in the code that
     actually branches on it.
-- **The *wire* form is a flat, schema-validated projection of that sum type.** JSON has no native sum
-    types; any consumer — `jq`, a shell `case`, a five-line Python script — branches on a discriminant
-    regardless of whether the bytes are flat or nested. A nested `{"focus": {...}|null, "meta": {...}}`
-    does not make the wire format self-checking; the consumer still has to know the `ok`/`error` rule.
-    What actually constrains the valid combinations on the wire is the **published JSON Schema**
-    (conditional `required`/`oneOf` on `ok`), which both flat and nested forms need equally. Given
-    that, the flat projection keeps the ergonomics (shallow paths, trivial `jq`) without giving up any
-    enforceable guarantee the nested form would have provided.
+- **The *wire* form is a flat, schema-validated projection of that sum type — and the schema itself
+    rejects the incoherent combinations.** JSON Schema can enforce cross-field coherence directly: a
+    `oneOf` over the success/failure variants, `if`/`then` (or `dependentRequired`), and `const`/`enum`
+    on the discriminant let the published schema make `{"ok": false, "focus_enabled": true, …}` *fail
+    validation*, require `error` exactly when `ok` is `false` (and forbid it when `ok` is `true`), and
+    require `focus_name` to be null when `focus_enabled` is false. So the "illegal states" guarantee is
+    enforceable on the wire, not only in the Rust model — and it holds for the **flat** object just as
+    well as for a nested one, so nesting buys no enforcement here. The one thing no schema (flat or
+    nested) can do is force an *ad-hoc consumer that never validates* — a `jq` or shell one-liner — to
+    branch correctly; JSON has no native sum types, so such a reader still keys off the `ok`/`error`
+    discriminant by hand. Net: the JSON Schema protects the contract boundary (producers, conformance
+    tests, validating clients), the internal sum type stops the producer from ever emitting nonsense,
+    and the flat projection keeps shallow paths and trivial `jq` — none of which nesting improves.
 
 In short: capture the "illegal states unrepresentable" guarantee in the strongly-typed *internal*
   model (where it has teeth), and let the *wire* contract be the flat projection plus its schema.

--- a/design/analyses/2026-05-12-macos-focus-db-format.md
+++ b/design/analyses/2026-05-12-macos-focus-db-format.md
@@ -83,8 +83,10 @@ Recommendation:
     least one *current* point release of that major. On that basis, `12.*`–`15.*` are reasonable
     `supported` entries once verified.
 - macOS **11 and earlier** are out of scope (different mechanism).
-- macOS **26** (and any future major) starts as `unknown until tested`; on a successful parse it is
-    reported as `unknown_but_working` until added to the table.
+- macOS **26** (and any future major) starts as `unknown until tested`; it is reported with the
+    `unknown` compatibility variant (carrying a "please report whether this version works" message)
+    until added to the table — whether parsing actually worked is conveyed by the result's outcome, not
+    the compatibility field.
 
 This analysis should be revisited whenever a new major macOS release ships, or whenever the parser
   encounters a `schema_unknown` failure in the field.

--- a/design/analyses/2026-05-12-macos-focus-db-format.md
+++ b/design/analyses/2026-05-12-macos-focus-db-format.md
@@ -1,0 +1,101 @@
+# macOS Focus Database Format and Stability
+
+## Question
+
+The [macOS Focus Gopher](../engineering-designs/2026-05-12-macos-focus-gopher.md) reads the current
+  Focus state from undocumented files under the user's home directory.
+Before committing to that approach — and before seeding the helper's macOS-version compatibility table —
+  we want to know:
+
+1. Where does macOS store Focus / Do Not Disturb state, and in what format?
+2. How long has that format existed, and how stable has it been across macOS releases?
+3. Can we reasonably support whole *major* macOS versions with a wildcard entry in the compatibility
+     table, or should we only ever claim support for specific point releases we have verified?
+
+## Findings
+
+### 1. Where the state lives, and the format
+
+Since **macOS 12 Monterey** (when "Focus" replaced the older standalone "Do Not Disturb"),
+  the state lives in JSON files under `~/Library/DoNotDisturb/DB/`, principally:
+
+- `Assertions.json` — the *active* state.
+    An active Focus shows up as an entry under `data[0].storeAssertionRecords`,
+    whose `assertionDetails.assertionDetailsModeIdentifier` (e.g. `com.apple.focus.personal-time`,
+    or a UUID for a user-created Focus) identifies which mode is on.
+    When no Focus is manually active the file is effectively empty
+    (an empty object, or a `data` array with no assertion records).
+- `ModeConfigurations.json` — the *configured* modes: a `data[0].modeConfigurations` map keyed by mode
+    UUID, each entry carrying the mode's human-readable `name`, symbol, and its triggers/schedule.
+    This is also where a *schedule- or automation-activated* Focus is reflected
+    (via the mode's trigger/`enabled` state), as opposed to a manual activation,
+    which appears in `Assertions.json` — a parser must consult both to get the full picture.
+
+Mapping an active identifier from `Assertions.json` to a display name requires cross-referencing
+  `ModeConfigurations.json` (and, for built-in Foci, a fixed identifier→name table).
+
+Before macOS 12 (Big Sur and earlier), Do Not Disturb was *not* stored this way — it lived in
+  Notification Center preference plists (e.g. `com.apple.ncprefs.plist`) with an entirely different
+  structure. That older mechanism is out of scope for this project; supporting it would require a
+  separate parser and is not planned.
+
+### 2. How long the format has existed, and how stable it has been
+
+The `~/Library/DoNotDisturb/DB/` JSON layout has been in place since macOS 12 (2021) and has been
+  relied on by a steady stream of community tools across macOS 12 Monterey, 13 Ventura, 14 Sonoma,
+  and 15 Sequoia without the core shape changing:
+
+- A widely-copied JXA snippet for reading the current Focus
+    ([drewkerr gist](https://gist.github.com/drewkerr/0f2b61ce34e2b9e3ce0ec6a92ab05c18)).
+- CLI tools such as [`davidolrik/getfocus`](https://github.com/davidolrik/getfocus) and
+    [`legnoh/focus-cli`](https://github.com/legnoh/focus-cli).
+- A detailed write-up of the file structure and the manual-vs-scheduled-activation wrinkle
+    ([brunerd, "Respecting Focus and Meeting Status in Your Mac scripts"](https://www.brunerd.com/blog/2022/03/07/respecting-focus-and-meeting-status-in-your-mac-scripts-aka-dont-be-a-jerk/)).
+- Long-running community threads tracking the approach across releases
+    ([Automators forum](https://talk.automators.fm/t/get-current-focus-mode-via-script/12423)).
+
+Caveats the same sources surface, which a robust parser must handle:
+
+- "No Focus active" is represented by an *empty/near-empty* `Assertions.json`, not by an explicit
+    "off" record — so an empty file is a valid, successful "Focus is off" result, not an error.
+- Manually-toggled Focus vs. schedule/automation-activated Focus appear in different files
+    (`Assertions.json` vs. a trigger state in `ModeConfigurations.json`).
+- Files can be momentarily absent or partially written while macOS updates them.
+- The format is still **undocumented and unsupported by Apple**; nothing prevents a future macOS
+    release from changing it.
+
+We did not find authoritative confirmation of the format on the current **macOS 26 Tahoe** release;
+  it is presumed similar but should be treated as unverified until we test it.
+
+### 3. Specific point releases vs. major-version wildcards
+
+Because the format is undocumented, the conservative default is to claim support only for versions we
+  have actually exercised. However, the evidence above is strong enough that the *major-version*
+  granularity is a reasonable unit for macOS 12–15: the layout has survived four major releases of
+  active community use without a breaking change, and Apple has shown no sign of reworking it.
+
+Recommendation:
+
+- The compatibility table is **keyed by macOS version string**, and an entry may be either a specific
+    point release (e.g. `15.5`) or a major-version wildcard (e.g. `15.*`).
+- A **major-version wildcard entry is allowed only when** (a) this analysis (or a future update to it)
+    finds the format stable for that major, and (b) the helper's parser has been verified against at
+    least one *current* point release of that major. On that basis, `12.*`–`15.*` are reasonable
+    `supported` entries once verified.
+- macOS **11 and earlier** are out of scope (different mechanism).
+- macOS **26** (and any future major) starts as `unknown until tested`; on a successful parse it is
+    reported as `unknown_but_working` until added to the table.
+
+This analysis should be revisited whenever a new major macOS release ships, or whenever the parser
+  encounters a `schema_unknown` failure in the field.
+
+## References
+
+- **Product Requirement**: [macOS Focus Gopher](../product-requirements/2026-05-12-macos-focus-gopher.md).
+- **Engineering Design**: [macOS Focus Gopher Engineering Design](../engineering-designs/2026-05-12-macos-focus-gopher.md).
+- Sources:
+  - [Read the current Focus mode on macOS Monterey (12.0+) using JXA — drewkerr gist](https://gist.github.com/drewkerr/0f2b61ce34e2b9e3ce0ec6a92ab05c18).
+  - [davidolrik/getfocus](https://github.com/davidolrik/getfocus).
+  - [legnoh/focus-cli](https://github.com/legnoh/focus-cli).
+  - [brunerd — Respecting Focus and Meeting Status in Your Mac scripts](https://www.brunerd.com/blog/2022/03/07/respecting-focus-and-meeting-status-in-your-mac-scripts-aka-dont-be-a-jerk/).
+  - [Automators forum — Get current focus mode via script](https://talk.automators.fm/t/get-current-focus-mode-via-script/12423).

--- a/design/analyses/2026-05-18-macos-fda-distribution-signing.md
+++ b/design/analyses/2026-05-18-macos-fda-distribution-signing.md
@@ -147,6 +147,41 @@ The message should print the *canonical resolved* executable path
 It does **not** enable programmatic FDA granting,
   and it does **not** remove the one-time manual System Settings step on any channel.
 
+### 6. Developing and testing locally without a Developer ID signature
+
+Because an unsigned/ad-hoc binary's TCC identity is its cdhash,
+  every rebuild produces a new identity and invalidates the Full Disk Access grant —
+  *even when the binary is rebuilt in place at a stable path*.
+A naive inner loop (build → run as a LaunchAgent against the live database → repeat) would therefore
+  require re-adding the binary in System Settings after every build,
+  which would make local development of this project genuinely painful.
+
+Three things defuse this, and together they should be the documented default workflow:
+
+- **Fixtures need no FDA.**
+  The fixture-based test strategy (captured `Assertions.json` / `ModeConfigurations.json` files in the
+    repo, not the TCC-protected path) means the bulk of the unit/integration suite reads ordinary files
+    and never touches TCC.
+  Full Disk Access is exercised only by live smoke tests and the end-to-end test.
+- **A self-signed local code-signing certificate gives a stable identity with no Apple account.**
+  A one-time Keychain step creates a self-signed code-signing certificate;
+    signing dev builds with it (`codesign -s "<local cert>"`) yields a stable TCC *Designated
+    Requirement* on the developer's machine, so the FDA grant **persists across rebuilds** —
+    the same property the shipped product only gains at M6, achievable locally for free.
+  This matters most for LaunchAgent-shape testing, where access is attributed to the helper binary
+    itself rather than to a parent process.
+- **Granting FDA to the responsible parent process covers run-from-terminal iteration.**
+  When the helper is run directly (not via the LaunchAgent), TCC attributes file access to the
+    responsible parent process, so granting Full Disk Access once to the developer's terminal/IDE lets
+    anything launched from it read the protected files without per-build re-granting.
+  (This grants broad FDA to that terminal — acceptable on a dev machine, and never part of the shipped
+    artifact.)
+
+The genuinely painful scenario occurs only if a developer uses none of these and tests exclusively
+  through the LaunchAgent path against the live database.
+The self-signed-certificate and responsible-process behaviors are the established approaches but are
+  version-sensitive, and belong in the same on-device verification bucket as the rest of this analysis.
+
 ## Recommendation
 
 - Treat **code signing + notarization** (and a **cask** channel) as
@@ -163,6 +198,11 @@ It does **not** enable programmatic FDA granting,
     (including that it must be re-granted after upgrades on the from-source channels).
 - Keep the **bundle / stable-identity architecture** (LaunchAgent and `.app` layout) intact;
     only the Developer ID **signature + notarization** and the **cask** channel are deferred.
+- **Document the local-development workflow** (fixtures-need-no-FDA, a self-signed dev signing
+    certificate, and terminal/responsible-process FDA), and ship a dev build task that signs with the
+    local certificate so it is the default path rather than tribal knowledge.
+  Capture it in the contributor docs of the first milestone that reads the protected files,
+    and again in the first milestone that builds the user LaunchAgent.
 
 This analysis should be revisited if the project gains an Apple Developer Program membership,
   if a cask channel is pursued, or if on-device verification contradicts the

--- a/design/analyses/2026-05-18-macos-fda-distribution-signing.md
+++ b/design/analyses/2026-05-18-macos-fda-distribution-signing.md
@@ -1,0 +1,187 @@
+# macOS Full Disk Access, Code Signing, and Distribution Channels
+
+## Question
+
+The [macOS Focus Gopher](../engineering-designs/2026-05-12-macos-focus-gopher.md) helper reads a
+  TCC-protected location (the Focus database under `~/Library/DoNotDisturb/DB/`),
+  which in practice requires the helper itself to hold **Full Disk Access (FDA)**.
+The original design assumed the helper would always be shipped as a
+  **code-signed and notarized `.app` bundle**.
+Before committing build, signing, and distribution effort, we want to know:
+
+1. What do code signing and notarization actually buy us, and what do they *not*?
+2. How does each preferred distribution channel — `cargo install` and Homebrew
+     (formula, tap, cask) — interact with signing, notarization, and the FDA grant?
+3. Can the helper detect and gracefully handle a missing FDA grant,
+     regardless of how it was distributed?
+4. Given the answers, what must early milestones do, and what can be deferred?
+
+## Findings
+
+### 1. The three macOS mechanisms in play
+
+- **Code-signing identity (what TCC uses to recognize "the same app" across updates).**
+  A **Developer ID** signature (a certificate held by the publisher; requires the paid Apple Developer
+    Program) makes TCC key the grant off the app's *Designated Requirement*
+    (bundle ID + Team ID), which is stable across rebuilds and versions —
+    so the FDA grant **persists across updates**.
+  An **unsigned or ad-hoc** binary (what a local compile produces by default;
+    Apple Silicon requires at least ad-hoc) is recognized by TCC via the binary's **cdhash**
+    (a content hash), which changes on every rebuild —
+    so the grant is **invalidated on every update** and must be re-granted.
+- **Notarization.**
+  The publisher uploads a Developer-ID-signed artifact to Apple for an automated malware scan,
+    then staples the returned ticket.
+  It requires Developer ID signing first (an unsigned/ad-hoc build cannot be notarized)
+    and the paid Apple Developer Program.
+- **Quarantine + Gatekeeper.**
+  The `com.apple.quarantine` attribute is set on *downloaded* artifacts.
+  On first launch of a quarantined artifact, Gatekeeper requires it to be Developer-ID-signed
+    **and** notarized, or it is blocked / shown a scary warning.
+  Locally compiled artifacts are **not** quarantined,
+    so Gatekeeper never gates them and **notarization is irrelevant** for them.
+
+The crux: notarization only matters *if the artifact is quarantined*,
+  and persistent FDA only happens *if the publisher ships its own stable Developer ID signature*.
+A from-source build cannot carry the publisher's signature (it is built on the user's machine),
+  so realistically it is a binary choice:
+  a **signed + notarized prebuilt** artifact, or an **unsigned/ad-hoc from-source** build.
+
+### 2. Full Disk Access can never be granted programmatically
+
+There is no `requestAuthorization`-style API that prompts for, and grants, Full Disk Access —
+  on any channel or signing state.
+The first-time FDA grant is **always** a manual trip to
+  System Settings → Privacy & Security → Full Disk Access.
+A signed, notarized, App Store app still requires this.
+
+This is specific to FDA (and its raw-disk siblings).
+Narrower scopes — Desktop, Documents, Downloads, removable/network volumes, Contacts, Calendar,
+  Photos, and similar — *do* have inline consent prompts whose "Allow" grants that scope immediately.
+The Focus database falls under broad FDA, not these friendlier per-folder prompts.
+
+What signing *does* improve here is **discoverability of the need**, not the grant itself:
+  on a denied access, macOS often surfaces a system-initiated *redirect* dialog
+  ("…go to System Settings", with an **Open System Settings** button)
+  and frequently pre-lists the app in the FDA pane (toggled off).
+That redirect reliably fires for **properly code-signed apps with a bundle identity**;
+  a bare **unsigned/ad-hoc CLI binary** (the build-from-source case)
+  often gets only a raw `EPERM` with **no dialog and no auto-listing**.
+This is why signed terminal apps (iTerm, Ghostty, Terminal) get OS signposting toward the FDA pane
+  while ad-hoc command-line tools tend to fail silently.
+
+Note: the exact redirect-dialog behavior (when it fires, for which signing state, per macOS major)
+  is version-sensitive and should be empirically verified on device
+  rather than asserted categorically.
+
+### 3. Detecting a missing FDA grant (`EPERM` vs. `ENOENT`)
+
+There is **no API to query the helper's own FDA status**; detection is necessarily *reactive*
+  (attempt the read, interpret the failure).
+
+- File exists, FDA held → `open()` succeeds.
+- File exists, FDA **not** held → `open()` returns **`EPERM`** ("Operation not permitted"),
+    *not* `ENOENT`.
+  This is the dependable "no FDA" signal on the primary read path.
+- File genuinely absent (Focus never configured) → `ENOENT` —
+    *but* `~/Library/DoNotDisturb` is a TCC-gated directory,
+    so when the process is unprivileged the gate can convert a would-be `ENOENT` into `EPERM`
+    (denied before existence can be revealed).
+  Directory enumeration without FDA is gated the same way (no trustworthy "empty directory").
+
+Therefore `EPERM` reliably means "denied" (overwhelmingly: no FDA),
+  while `ENOENT` is only trustworthy as "absent" once access is already confirmed.
+The benign "Focus is off" state is represented by *empty file content*, not file absence,
+  so it is an `open()`-success-plus-empty case, not an `ENOENT` case
+  (see the [format-stability analysis](2026-05-12-macos-focus-db-format.md)).
+
+This detection works **on every channel and signing state** — it is unaffected by not signing.
+Per [Comprehensive Error Modeling](../engineering-principles/2026-01-08-error-modeling.md) and
+  [Clear, Unambiguous, Easily-Parsed Data Models](../engineering-principles/2026-05-12-clear-data-models.md),
+  the denied case must surface as its **own dedicated error code** with actionable, deep-linked
+  remediation (the resolved binary path to add, and the
+  `x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles` deep link),
+  and must **never** be collapsed into `ok: true, focus_enabled: false`.
+The message should print the *canonical resolved* executable path
+  (cargo and Homebrew both symlink into `bin/`, and TCC matches the real binary,
+  so naming the symlink can misfire).
+
+### 4. Per-channel impact
+
+| Channel | Quarantined? | Notarization | Signature the publisher can ship | FDA across updates | Apple acct |
+| --- | --- | --- | --- | --- | --- |
+| `cargo install` | No | N/A | ad-hoc only (local build) | Re-grant each update | No |
+| Homebrew formula | No | N/A | ad-hoc only (local build / Homebrew-CI bottle) | Re-grant each update | No |
+| Homebrew tap | inherits | inherits | inherits | inherits | inherits |
+| Homebrew cask | **Yes** | **Required** | **Developer ID** (prebuilt) | **Persists** | **Yes ($99/yr)** |
+
+- **`cargo install`** compiles on the user's machine and installs a bare binary into `~/.cargo/bin/`
+    (not an `.app`, not a LaunchAgent).
+  Not quarantined (notarization irrelevant); ad-hoc identity (FDA re-granted every upgrade);
+    no Apple account; the worst case for first-run signposting (often silent `EPERM`).
+- **Homebrew formula** builds from source on the user's machine (or installs a Homebrew-CI-built
+    bottle); either way the artifact is not quarantined and not publisher-signed —
+    functionally equivalent to the `cargo install` story for our purposes.
+- **Homebrew tap** is a *delivery vehicle*, not a packaging type:
+    a third-party repo containing a formula or a cask.
+  It changes nothing about signing/notarization; it inherits the behavior of whatever it contains.
+  It is relevant only because this project will not be in homebrew-core
+    (third-party notability rules), so a tap is the realistic channel either way.
+- **Homebrew cask** installs a prebuilt artifact the publisher produces and hosts.
+  Homebrew **quarantines casks by default**, so the `.app` is Gatekeeper-gated on first launch and
+    must, in practice, be Developer-ID-signed **and** notarized
+    (the `--no-quarantine` escape hatch is a security smell and a poor default for an FDA tool).
+  Because it ships the publisher's stable Developer ID signature,
+    this is the **only** channel where the FDA grant persists across updates
+    and where the OS redirect dialog reliably appears.
+
+### 5. What signing + notarization actually buys this project
+
+- **FDA persists across updates** (stable Developer ID identity vs. per-build cdhash) —
+    the only channel that delivers this is the signed + notarized **cask**.
+- **Better first-run discoverability** — the OS redirect dialog and FDA-pane pre-listing
+    fire for signed bundles, where the bare-binary channels often fail silently.
+- **Clears the Gatekeeper launch wall** that a quarantining **cask** would otherwise hit
+    (a notarization-only benefit, irrelevant to the non-quarantined from-source channels).
+
+It does **not** enable programmatic FDA granting,
+  and it does **not** remove the one-time manual System Settings step on any channel.
+
+## Recommendation
+
+- Treat **code signing + notarization** (and a **cask** channel) as
+    *nice-to-have UX improvements*, not prerequisites for usefulness.
+  Defer them to a **final, optional milestone** that may or may not be reached.
+- Target **build-from-source** distribution (`cargo install`, Homebrew formula/tap) for the
+    earlier milestones: no Apple Developer account, no notarization,
+    accepting that the user re-grants FDA after each upgrade
+    and that the helper's own error message is the primary first-run signpost.
+- Make **graceful missing-FDA handling a first-class, early requirement**:
+    a dedicated permission-denied error code,
+    an actionable deep-linked `message` (resolved binary path + Settings deep link),
+    and `README`/`--help`/`man` documentation of exactly how to grant FDA
+    (including that it must be re-granted after upgrades on the from-source channels).
+- Keep the **bundle / stable-identity architecture** (LaunchAgent and `.app` layout) intact;
+    only the Developer ID **signature + notarization** and the **cask** channel are deferred.
+
+This analysis should be revisited if the project gains an Apple Developer Program membership,
+  if a cask channel is pursued, or if on-device verification contradicts the
+  `EPERM`/redirect-dialog behavior described here.
+
+## References
+
+- **Product Vision**: [macOS Focus Gopher](../product-vision/2026-05-12-macos-focus-gopher.md).
+- **Product Requirement**: [macOS Focus Gopher](../product-requirements/2026-05-12-macos-focus-gopher.md).
+- **Engineering Design**: [macOS Focus Gopher Engineering Design](../engineering-designs/2026-05-12-macos-focus-gopher.md).
+- **Delivery Plan**: [macOS Focus Gopher Delivery Plan](../delivery-plans/2026-05-12-macos-focus-gopher.md).
+- **Related Analyses**:
+    [macOS Focus Database Format and Stability](2026-05-12-macos-focus-db-format.md);
+    [`FocusState` JSON Response Shape: Flat vs. Nested](2026-05-12-focus-state-json-shape.md).
+- **Engineering Principles**:
+    [Least Privilege](../engineering-principles/2026-05-12-least-privilege.md);
+    [Comprehensive Error Modeling](../engineering-principles/2026-01-08-error-modeling.md);
+    [Clear, Unambiguous, Easily-Parsed Data Models](../engineering-principles/2026-05-12-clear-data-models.md);
+    [YAGNI](../engineering-principles/2026-01-06-yagni.md).
+- macOS TCC / Gatekeeper / notarization behavior described here reflects established platform behavior
+    as of this writing; the version-exact `EPERM` and redirect-dialog specifics
+    are flagged for empirical verification during the on-device milestones (see the delivery plan).

--- a/design/analyses/2026-05-18-macos-fda-distribution-signing.md
+++ b/design/analyses/2026-05-18-macos-fda-distribution-signing.md
@@ -221,7 +221,7 @@ This analysis should be revisited if the project gains an Apple Developer Progra
 - **Delivery Plan**: [macOS Focus Gopher Delivery Plan](../delivery-plans/2026-05-12-macos-focus-gopher.md).
 - **Related Analyses**:
     [macOS Focus Database Format and Stability](2026-05-12-macos-focus-db-format.md);
-    [`FocusState` JSON Response Shape: Flat vs. Nested](2026-05-12-focus-state-json-shape.md).
+    [`FocusState` JSON Response Shape: Flat vs. Tagged Union](2026-05-12-focus-state-json-shape.md).
 - **Engineering Principles**:
     [Least Privilege](../engineering-principles/2026-05-12-least-privilege.md);
     [Comprehensive Error Modeling](../engineering-principles/2026-01-08-error-modeling.md);

--- a/design/analyses/2026-05-18-macos-fda-distribution-signing.md
+++ b/design/analyses/2026-05-18-macos-fda-distribution-signing.md
@@ -60,14 +60,18 @@ Narrower scopes — Desktop, Documents, Downloads, removable/network volumes, Co
   Photos, and similar — *do* have inline consent prompts whose "Allow" grants that scope immediately.
 The Focus database falls under broad FDA, not these friendlier per-folder prompts.
 
-What signing *does* improve here is **discoverability of the need**, not the grant itself:
-  on a denied access, macOS often surfaces a system-initiated *redirect* dialog
-  ("…go to System Settings", with an **Open System Settings** button)
-  and frequently pre-lists the app in the FDA pane (toggled off).
-That redirect reliably fires for **properly code-signed apps with a bundle identity**;
-  a bare **unsigned/ad-hoc CLI binary** (the build-from-source case)
-  often gets only a raw `EPERM` with **no dialog and no auto-listing**.
-This is why signed terminal apps (iTerm, Ghostty, Terminal) get OS signposting toward the FDA pane
+What signing *does* improve here is **discoverability of the need**, not the grant itself — and it is
+  a pure side channel that the app never sees.
+In **both** the signed and unsigned cases the FDA-gated operation itself fails identically: the app
+  receives an `EPERM` and nothing more.
+The difference is what macOS does *alongside* that failure, out of band: for a **properly code-signed
+  app with a bundle identity**, the system often raises a *redirect* dialog
+  ("…go to System Settings", with an **Open System Settings** button) and pre-lists the app in the Full
+  Disk Access pane (toggled off, ready to flip); for a bare **unsigned/ad-hoc CLI binary** (the
+  build-from-source case) it typically raises no dialog and adds no pre-listing.
+The app cannot observe, trigger, or depend on that dialog either way — it only ever sees the `EPERM` —
+  so this is purely a human-facing convenience, not anything the helper's own error handling can lean on.
+This is why signed apps (iTerm, Ghostty, Terminal) get OS signposting toward the FDA pane
   while ad-hoc command-line tools tend to fail silently.
 
 Note: the exact redirect-dialog behavior (when it fires, for which signing state, per macOS major)

--- a/design/analyses/2026-05-18-macos-fda-distribution-signing.md
+++ b/design/analyses/2026-05-18-macos-fda-distribution-signing.md
@@ -102,10 +102,11 @@ The benign "Focus is off" state is represented by *empty file content*, not file
 This detection works **on every channel and signing state** — it is unaffected by not signing.
 Per [Comprehensive Error Modeling](../engineering-principles/2026-01-08-error-modeling.md) and
   [Clear, Unambiguous, Easily-Parsed Data Models](../engineering-principles/2026-05-12-clear-data-models.md),
-  the denied case must surface as its **own dedicated error code** with actionable, deep-linked
-  remediation (the resolved binary path to add, and the
+  the denied case must surface as its **own dedicated error code** (`focus_permission_denied`, a
+  `failed` outcome) with actionable, deep-linked remediation in the `failed` variant's `message` (the
+  resolved binary path to add, and the
   `x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles` deep link),
-  and must **never** be collapsed into `ok: true, focus_enabled: false`.
+  and must **never** be collapsed into a `determined` result.
 The message should print the *canonical resolved* executable path
   (cargo and Homebrew both symlink into `bin/`, and TCC matches the real binary,
   so naming the symlink can misfire).

--- a/design/delivery-plans/2026-05-12-macos-focus-gopher.md
+++ b/design/delivery-plans/2026-05-12-macos-focus-gopher.md
@@ -155,9 +155,9 @@ Per the [FDA / signing / distribution analysis](../analyses/2026-05-18-macos-fda
 **In scope:**
 
 - Maintain/expand the compatibility table: add macOS versions as they are verified (updating the
-    format-stability analysis as needed), wire `macos_compatibility: unknown_but_working` (parsing
-    succeeded on an unlisted version) with the "please submit an issue or PR" `message`, and the
-    parse-failure `message` asking for an issue/PR with macOS version, helper version, and error code.
+    format-stability analysis as needed), wire the `macos_compatibility` `unknown` variant (version on
+    neither list) carrying its "please report whether this works" `message`, and the `failed` variant's
+    guidance `message` asking for an issue/PR with macOS version, helper version, and error code.
 - Contributor documentation: how to add support for a new macOS version (capture fixtures, adjust the
     parser if the schema changed, add the table entry, add tests).
 - Ship bundled **agent skills** plus a command that installs them into the user's home directory or a

--- a/design/delivery-plans/2026-05-12-macos-focus-gopher.md
+++ b/design/delivery-plans/2026-05-12-macos-focus-gopher.md
@@ -44,7 +44,7 @@ Per the [FDA / signing / distribution analysis](../analyses/2026-05-18-macos-fda
 - Define the `FocusState` model, publish its versioned **JSON Schema**, and define the line-delimited
     JSON request/response protocol over a per-user Unix domain socket.
 - Implement `get_focus()` as a stub that returns a well-formed `FocusState`
-    (e.g. `ok: false`, `error: "macos_unsupported"`) without touching any database file.
+    (e.g. a `failed` outcome with `error: "macos_unsupported"`) without touching any database file.
 - Unit tests for `FocusState` encoding/decoding, JSON-Schema validation, and the socket round-trip.
 - Initial `README.md` (clearly marked early-development / not yet usable), an OSS `LICENSE` (MIT), and a
     `CONTRIBUTING.md` stub that points at the repository-root `CONTRIBUTING.md` and these design docs.
@@ -61,7 +61,7 @@ Per the [FDA / signing / distribution analysis](../analyses/2026-05-18-macos-fda
 **In scope:**
 
 - Implement the thin `focus-gopher` CLI: it connects to the socket, performs `get_focus()`, prints the
-    `FocusState` as JSON, and exits non-zero when `ok` is `false` (zero otherwise).
+    `FocusState` as JSON, and exits non-zero when the outcome is `failed` (zero otherwise).
 - `--help` output with worked examples.
 - Tests covering the CLI round-trip and exit-code behavior.
 - `README.md` updated with CLI usage (so the service is usable without `socat`/`nc` + `jq`).
@@ -85,8 +85,8 @@ Per the [FDA / signing / distribution analysis](../analyses/2026-05-18-macos-fda
     analysis (the macOS 12–15 majors, verified against a current point release of each).
 - The full failure taxonomy with explicit `error` codes
     (`focus_permission_denied`, `focus_db_unreadable`, `focus_db_malformed`, `schema_unknown`,
-    `macos_unsupported`, `internal_error`), with a parse/schema/permission failure never reported as
-    `ok: true, focus_enabled: false`.
+    `focus_name_unresolved`, `macos_unsupported`, `internal_error`), with a parse/schema/permission/
+    name-resolution failure never reported as a `determined` result.
 - **Graceful missing-FDA handling:** an `EPERM` on the (existing) Focus database is mapped to the
     dedicated `focus_permission_denied` code with an actionable `message` — the *canonical resolved*
     helper binary path to add, plus the
@@ -94,7 +94,8 @@ Per the [FDA / signing / distribution analysis](../analyses/2026-05-18-macos-fda
     [FDA / signing / distribution analysis](../analyses/2026-05-18-macos-fda-distribution-signing.md).
 - Fixture-based unit/integration tests: captured `Assertions.json` / `ModeConfigurations.json` shapes
     for manual-Focus-on, scheduled-Focus-on, Focus-off (including the empty file), malformed,
-    unknown-schema, and permission-denied (`EPERM`) cases, per supported macOS major.
+    unknown-schema, permission-denied (`EPERM`), and unnameable-active-Focus (`focus_name_unresolved`)
+    cases, per supported macOS major.
 - `README.md` updated to reflect "works on macOS 12–15, run from source", **including a clear
     "grant Full Disk Access to the helper" section** (the exact System Settings steps, and that the
     grant must be re-applied after each upgrade on the build-from-source channels).
@@ -211,5 +212,5 @@ Everything in M1–M5 is fully usable without it; per the
 - **Product Requirements**: [macOS Focus Gopher](../product-requirements/2026-05-12-macos-focus-gopher.md).
 - **Engineering Design**: [macOS Focus Gopher Engineering Design](../engineering-designs/2026-05-12-macos-focus-gopher.md).
 - **Analyses**: [macOS Focus Database Format and Stability](../analyses/2026-05-12-macos-focus-db-format.md);
-    [`FocusState` JSON Response Shape: Flat vs. Nested](../analyses/2026-05-12-focus-state-json-shape.md);
+    [`FocusState` JSON Response Shape: Flat vs. Tagged Union](../analyses/2026-05-12-focus-state-json-shape.md);
     [macOS Full Disk Access, Code Signing, and Distribution Channels](../analyses/2026-05-18-macos-fda-distribution-signing.md).

--- a/design/delivery-plans/2026-05-12-macos-focus-gopher.md
+++ b/design/delivery-plans/2026-05-12-macos-focus-gopher.md
@@ -186,8 +186,11 @@ Everything in M1–M5 is fully usable without it; per the
     artifact (clears the Gatekeeper launch wall that quarantined casks otherwise hit).
 - The payoff, documented in the `README.md`: the Full Disk Access grant now **persists across
     updates** (TCC keys off the stable Developer ID identity rather than the per-build cdhash), and the
-    OS surfaces its redirect dialog / FDA-pane pre-listing on first denial. The build-from-source
-    channels (M4) remain supported and unchanged for users without the signed channel.
+    OS surfaces its redirect dialog / FDA-pane pre-listing on first denial. That signposting is a
+    human-facing *side channel* the helper never sees — the FDA-gated read still returns the same
+    permission error either way — so it changes only the install UX, not the helper's behavior or its
+    `focus_permission_denied` handling. The build-from-source channels (M4) remain supported and
+    unchanged for users without the signed channel.
 
 **Deliverable:** a signed + notarized `brew install --cask …` path whose Full Disk Access grant
   survives upgrades, alongside the still-supported build-from-source channels.

--- a/design/delivery-plans/2026-05-12-macos-focus-gopher.md
+++ b/design/delivery-plans/2026-05-12-macos-focus-gopher.md
@@ -9,11 +9,11 @@ This plan sequences delivery of the
 
 The main delivery risk is the *undocumented, version-fragile Focus database*
   (see the [format-stability analysis](../analyses/2026-05-12-macos-focus-db-format.md)).
-The plan front-loads the stable parts (the project skeleton and the wire contract),
-  then tackles parsing for the verified macOS versions, then packaging/distribution, then compatibility
-  breadth and the agent ecosystem — so each milestone delivers something a consumer or contributor can
-  actually exercise, and so a parser surprise on a future macOS version does not block the earlier
-  milestones.
+The plan front-loads the stable parts (the project skeleton and the wire contract), then the CLI
+  wrapper (so the service is usable without `socat`/`nc` + `jq`), then parsing for the verified macOS
+  versions, then packaging/distribution, then compatibility breadth and the agent ecosystem — so each
+  milestone delivers something a consumer or contributor can actually exercise, and so a parser surprise
+  on a future macOS version does not block the earlier milestones.
 
 ## Delivery Conventions
 
@@ -29,27 +29,41 @@ The plan front-loads the stable parts (the project skeleton and the wire contrac
 
 **In scope:**
 
-- Scaffold `macos-focus-gopher/` at the repo root: a Rust crate (the helper binary plus the
-    `focus-gopher` CLI wrapper) and the `.app` bundle packaging, a `mise.toml` exposing
+- Scaffold `macos-focus-gopher/` at the repo root: a Rust crate (the helper binary; the CLI binary is
+    stubbed in but not yet wired up) and the `.app` bundle packaging, a `mise.toml` exposing
     `build` / `test` / `lint` / `dependencies:check` / `dependencies:update` / `ci`, wired into the
     root `mise.toml`, and CI invoking those Mise tasks.
 - Define the `FocusState` model, publish its versioned **JSON Schema**, and define the line-delimited
-    JSON request/response protocol over a per-user Unix domain socket; the CLI wrapper relays
-    `get_focus()` over that socket and prints the result.
+    JSON request/response protocol over a per-user Unix domain socket.
 - Implement `get_focus()` as a stub that returns a well-formed `FocusState`
     (e.g. `ok: false`, `error: "macos_unsupported"`) without touching any database file.
-- Unit tests for `FocusState` encoding/decoding, schema validation, and the socket/CLI round-trip.
+- Unit tests for `FocusState` encoding/decoding, JSON-Schema validation, and the socket round-trip.
 - Initial `README.md` (clearly marked early-development / not yet usable), an OSS `LICENSE` (MIT), and a
     `CONTRIBUTING.md` stub that points at the repository-root `CONTRIBUTING.md` and these design docs.
 
-**Deliverable:** the project builds, tests, and lints in CI;
-  a local client can connect to the running helper over the socket — or run `focus-gopher` — and
-  receive a well-formed (stubbed) `FocusState` that validates against the published schema.
+**Deliverable:** the project builds, tests, and lints in CI; a local client can connect to the running
+  helper over the socket and receive a well-formed (stubbed) `FocusState` that validates against the
+  published schema. (For local poking before M2, a raw socket tool like `nc`/`socat` is enough.)
 
-**Deferred to later milestones:** any real Focus parsing; packaging as an installed LaunchAgent;
-  distribution.
+**Deferred to later milestones:** the CLI wrapper; any real Focus parsing; packaging as an installed
+  LaunchAgent; distribution.
 
-### M2 — Read-only Focus parsing on the verified macOS versions
+### M2 — The `focus-gopher` CLI wrapper
+
+**In scope:**
+
+- Implement the thin `focus-gopher` CLI: it connects to the socket, performs `get_focus()`, prints the
+    `FocusState` as JSON, and exits non-zero when `ok` is `false` (zero otherwise).
+- `--help` output with worked examples.
+- Tests covering the CLI round-trip and exit-code behavior.
+- `README.md` updated with CLI usage (so the service is usable without `socat`/`nc` + `jq`).
+
+**Deliverable:** a human or agent can run `focus-gopher` and get the (stubbed, until M3) `FocusState`
+  without touching the raw socket.
+
+**Deferred:** real Focus parsing; packaging/install; distribution.
+
+### M3 — Read-only Focus parsing on the verified macOS versions
 
 **In scope:**
 
@@ -67,15 +81,15 @@ The plan front-loads the stable parts (the project skeleton and the wire contrac
 - Fixture-based unit/integration tests: captured `Assertions.json` / `ModeConfigurations.json` shapes
     for manual-Focus-on, scheduled-Focus-on, Focus-off (including the empty file), malformed, and
     unknown-schema cases, per supported macOS major.
-- `README.md` updated to reflect "works on macOS 12–15, run from source"; first cut of `--help` output
-    with examples.
+- `README.md` updated to reflect "works on macOS 12–15, run from source".
 
-**Deliverable:** `get_focus()` returns a correct `FocusState` for Focus-on (manual and scheduled) and
-  Focus-off on the supported macOS versions, and an explicit error on unreadable/malformed/unknown data.
+**Deliverable:** `get_focus()` (via socket or `focus-gopher`) returns a correct `FocusState` for
+  Focus-on (manual and scheduled) and Focus-off on the supported macOS versions, and an explicit error
+  on unreadable/malformed/unknown data.
 
 **Deferred:** packaging/install; distribution; broader macOS version coverage; bundled agent skills.
 
-### M3 — Packaging, install, and distribution
+### M4 — Packaging, install, and distribution
 
 **In scope:**
 
@@ -87,8 +101,8 @@ The plan front-loads the stable parts (the project skeleton and the wire contrac
     `PATH` — installs with a single command.
 - Documentation of the macOS privacy permission the *helper* needs (Full Disk Access, if required) and
     how to grant it — and confirmation that no client receives any permission as a result.
-- An end-to-end test: a client connects to the installed, running helper (and the CLI wrapper works)
-    and receives a `FocusState` (against a real macOS session where feasible; otherwise the real
+- An end-to-end test: a client connects to the installed, running helper (and `focus-gopher` works) and
+    receives a `FocusState` (against a real macOS session where feasible; otherwise the real
     socket/process over fixture data).
 - `README.md` updated with one-command install instructions and a short, deliberately slow/clear
     screen-recording GIF; a `man` page.
@@ -98,7 +112,7 @@ The plan front-loads the stable parts (the project skeleton and the wire contrac
 
 **Deferred:** auto-update; broader macOS version coverage; bundled agent skills.
 
-### M4 — Compatibility breadth, the agent ecosystem, and docs polish
+### M5 — Compatibility breadth, the agent ecosystem, and docs polish
 
 **In scope:**
 
@@ -119,8 +133,8 @@ The plan front-loads the stable parts (the project skeleton and the wire contrac
 
 ## Explicitly Deferred (out of scope for this plan)
 
-- A packaged client library (Rust, Python, or otherwise) for consumers — clients can speak the
-    documented socket protocol or use the CLI wrapper until there is a concrete need.
+- A packaged client *library* (Rust, Python, or otherwise) for consumers — clients can speak the
+    documented socket protocol or use the `focus-gopher` CLI until there is a concrete need.
 - Distribution beyond Homebrew (e.g. a standalone downloadable installer) and auto-update.
 - Any operation beyond `get_focus()` — the narrow API is the point.
 
@@ -129,4 +143,5 @@ The plan front-loads the stable parts (the project skeleton and the wire contrac
 - **Product Vision**: [macOS Focus Gopher](../product-vision/2026-05-12-macos-focus-gopher.md).
 - **Product Requirements**: [macOS Focus Gopher](../product-requirements/2026-05-12-macos-focus-gopher.md).
 - **Engineering Design**: [macOS Focus Gopher Engineering Design](../engineering-designs/2026-05-12-macos-focus-gopher.md).
-- **Analysis**: [macOS Focus Database Format and Stability](../analyses/2026-05-12-macos-focus-db-format.md).
+- **Analyses**: [macOS Focus Database Format and Stability](../analyses/2026-05-12-macos-focus-db-format.md);
+    [`FocusState` JSON Response Shape: Flat vs. Nested](../analyses/2026-05-12-focus-state-json-shape.md).

--- a/design/delivery-plans/2026-05-12-macos-focus-gopher.md
+++ b/design/delivery-plans/2026-05-12-macos-focus-gopher.md
@@ -11,9 +11,17 @@ The main delivery risk is the *undocumented, version-fragile Focus database*
   (see the [format-stability analysis](../analyses/2026-05-12-macos-focus-db-format.md)).
 The plan front-loads the stable parts (the project skeleton and the wire contract), then the CLI
   wrapper (so the service is usable without `socat`/`nc` + `jq`), then parsing for the verified macOS
-  versions, then packaging/distribution, then compatibility breadth and the agent ecosystem — so each
-  milestone delivers something a consumer or contributor can actually exercise, and so a parser surprise
-  on a future macOS version does not block the earlier milestones.
+  versions, then build-from-source packaging/distribution, then compatibility breadth and the agent
+  ecosystem — so each milestone delivers something a consumer or contributor can actually exercise, and
+  so a parser surprise on a future macOS version does not block the earlier milestones.
+
+Per the [FDA / signing / distribution analysis](../analyses/2026-05-18-macos-fda-distribution-signing.md),
+  **code signing and notarization are deferred to a final, optional milestone (M6) that may or may not
+  be reached.** The earlier milestones ship build-from-source distribution (`cargo install`, Homebrew
+  formula/tap), which need no Apple Developer account and no notarization. Because Full Disk Access can
+  never be granted programmatically and is invalidated on every upgrade of an unsigned build, **graceful
+  missing-FDA handling — a dedicated error code, an actionable deep-linked message, and clear
+  documentation — is a first-class concern of the earlier milestones, not something M6 introduces.**
 
 ## Delivery Conventions
 
@@ -76,12 +84,20 @@ The plan front-loads the stable parts (the project skeleton and the wire contrac
 - The compatibility-table lookup feeding `macos_compatibility`, seeded per the format-stability
     analysis (the macOS 12–15 majors, verified against a current point release of each).
 - The full failure taxonomy with explicit `error` codes
-    (`focus_db_unreadable`, `focus_db_malformed`, `schema_unknown`, `macos_unsupported`,
-    `internal_error`), with a parse/schema failure never reported as `ok: true, focus_enabled: false`.
+    (`focus_permission_denied`, `focus_db_unreadable`, `focus_db_malformed`, `schema_unknown`,
+    `macos_unsupported`, `internal_error`), with a parse/schema/permission failure never reported as
+    `ok: true, focus_enabled: false`.
+- **Graceful missing-FDA handling:** an `EPERM` on the (existing) Focus database is mapped to the
+    dedicated `focus_permission_denied` code with an actionable `message` — the *canonical resolved*
+    helper binary path to add, plus the
+    `x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles` deep link — per the
+    [FDA / signing / distribution analysis](../analyses/2026-05-18-macos-fda-distribution-signing.md).
 - Fixture-based unit/integration tests: captured `Assertions.json` / `ModeConfigurations.json` shapes
-    for manual-Focus-on, scheduled-Focus-on, Focus-off (including the empty file), malformed, and
-    unknown-schema cases, per supported macOS major.
-- `README.md` updated to reflect "works on macOS 12–15, run from source".
+    for manual-Focus-on, scheduled-Focus-on, Focus-off (including the empty file), malformed,
+    unknown-schema, and permission-denied (`EPERM`) cases, per supported macOS major.
+- `README.md` updated to reflect "works on macOS 12–15, run from source", **including a clear
+    "grant Full Disk Access to the helper" section** (the exact System Settings steps, and that the
+    grant must be re-applied after each upgrade on the build-from-source channels).
 
 **Deliverable:** `get_focus()` (via socket or `focus-gopher`) returns a correct `FocusState` for
   Focus-on (manual and scheduled) and Focus-off on the supported macOS versions, and an explicit error
@@ -89,28 +105,35 @@ The plan front-loads the stable parts (the project skeleton and the wire contrac
 
 **Deferred:** packaging/install; distribution; broader macOS version coverage; bundled agent skills.
 
-### M4 — Packaging, install, and distribution
+### M4 — Build-from-source packaging, install, and distribution
 
 **In scope:**
 
-- A code-signed and notarized `.app` bundle, installed at the stable path, with a stable bundle
-    identifier and signing identity.
+- An (unsigned / ad-hoc-signed) `.app` bundle laid out at the stable path with the stable bundle
+    identifier — the full bundle/LaunchAgent *architecture*, minus the Developer ID signature and
+    notarization (deferred to M6).
 - A per-user LaunchAgent plist and the install/uninstall flow that registers/unregisters it; socket
     lifecycle management (create on launch, clean up on exit, single-instance behavior).
-- A Homebrew formula (or tap) so the whole thing — bundle, LaunchAgent registration, `focus-gopher` on
-    `PATH` — installs with a single command.
-- Documentation of the macOS privacy permission the *helper* needs (Full Disk Access, if required) and
-    how to grant it — and confirmation that no client receives any permission as a result.
+- Build-from-source distribution: a Homebrew **formula (in a tap)** and `cargo install`, so the whole
+    thing — bundle, LaunchAgent registration, `focus-gopher` on `PATH` — installs with a single
+    command, with no Apple Developer account required (see the
+    [FDA / signing / distribution analysis](../analyses/2026-05-18-macos-fda-distribution-signing.md)).
+- Documentation of the Full Disk Access grant the *helper* needs and exactly how to grant it,
+    **prominently including that an unsigned/from-source build's grant is invalidated on every upgrade
+    and must be re-applied** — and confirmation that no client receives any permission as a result.
 - An end-to-end test: a client connects to the installed, running helper (and `focus-gopher` works) and
     receives a `FocusState` (against a real macOS session where feasible; otherwise the real
-    socket/process over fixture data).
+    socket/process over fixture data), explicitly covering the `focus_permission_denied` path when FDA
+    is absent.
 - `README.md` updated with one-command install instructions and a short, deliberately slow/clear
     screen-recording GIF; a `man` page.
 
-**Deliverable:** an installable helper (`brew install …`) that an unprivileged out-of-process client can
-  query, with honest install-and-use docs.
+**Deliverable:** an installable helper (`brew install …` from a tap, or `cargo install`) that an
+  unprivileged out-of-process client can query, with honest install-and-use docs that set correct
+  expectations about the manual (and per-upgrade) Full Disk Access grant.
 
-**Deferred:** auto-update; broader macOS version coverage; bundled agent skills.
+**Deferred:** code signing, notarization, and cask distribution (M6); auto-update; broader macOS
+  version coverage; bundled agent skills.
 
 ### M5 — Compatibility breadth, the agent ecosystem, and docs polish
 
@@ -131,11 +154,38 @@ The plan front-loads the stable parts (the project skeleton and the wire contrac
   documented path for contributors to extend coverage, and a project that is easy for humans and agents
   to discover, install, and use.
 
+### M6 — Code signing, notarization, and signed-update distribution (optional; may not be reached)
+
+This milestone is a **nice-to-have UX improvement**, explicitly optional, and may never be done.
+Everything in M1–M5 is fully usable without it; per the
+  [FDA / signing / distribution analysis](../analyses/2026-05-18-macos-fda-distribution-signing.md)
+  signing/notarization do **not** enable programmatic FDA granting and do **not** remove the one-time
+  manual grant — their value is narrower and incremental.
+
+**Prerequisite:** an Apple Developer Program membership ($99/yr) and a Developer ID certificate.
+
+**In scope (the incremental UX wins):**
+
+- Developer ID signing + Apple notarization of the existing `.app` bundle, with a stable signing
+    identity, wired into the release pipeline.
+- A Homebrew **cask** distributing the prebuilt, signed + notarized bundle from a hosted release
+    artifact (clears the Gatekeeper launch wall that quarantined casks otherwise hit).
+- The payoff, documented in the `README.md`: the Full Disk Access grant now **persists across
+    updates** (TCC keys off the stable Developer ID identity rather than the per-build cdhash), and the
+    OS surfaces its redirect dialog / FDA-pane pre-listing on first denial. The build-from-source
+    channels (M4) remain supported and unchanged for users without the signed channel.
+
+**Deliverable:** a signed + notarized `brew install --cask …` path whose Full Disk Access grant
+  survives upgrades, alongside the still-supported build-from-source channels.
+
+**Deferred:** auto-update.
+
 ## Explicitly Deferred (out of scope for this plan)
 
 - A packaged client *library* (Rust, Python, or otherwise) for consumers — clients can speak the
     documented socket protocol or use the `focus-gopher` CLI until there is a concrete need.
-- Distribution beyond Homebrew (e.g. a standalone downloadable installer) and auto-update.
+- Distribution beyond `cargo install` and Homebrew (formula/tap, plus the optional M6 cask) —
+    e.g. a standalone downloadable installer — and auto-update.
 - Any operation beyond `get_focus()` — the narrow API is the point.
 
 ## References
@@ -144,4 +194,5 @@ The plan front-loads the stable parts (the project skeleton and the wire contrac
 - **Product Requirements**: [macOS Focus Gopher](../product-requirements/2026-05-12-macos-focus-gopher.md).
 - **Engineering Design**: [macOS Focus Gopher Engineering Design](../engineering-designs/2026-05-12-macos-focus-gopher.md).
 - **Analyses**: [macOS Focus Database Format and Stability](../analyses/2026-05-12-macos-focus-db-format.md);
-    [`FocusState` JSON Response Shape: Flat vs. Nested](../analyses/2026-05-12-focus-state-json-shape.md).
+    [`FocusState` JSON Response Shape: Flat vs. Nested](../analyses/2026-05-12-focus-state-json-shape.md);
+    [macOS Full Disk Access, Code Signing, and Distribution Channels](../analyses/2026-05-18-macos-fda-distribution-signing.md).

--- a/design/delivery-plans/2026-05-12-macos-focus-gopher.md
+++ b/design/delivery-plans/2026-05-12-macos-focus-gopher.md
@@ -1,0 +1,102 @@
+# macOS Focus Gopher Delivery Plan
+
+## Overview
+
+This plan sequences delivery of the [macOS Focus Gopher](../product-requirements/2026-05-12-macos-focus-gopher.md)
+  requirement into thin, independently-testable milestones,
+  per the [engineering design](../engineering-designs/2026-05-12-macos-focus-gopher.md).
+
+The main delivery risk is the *undocumented, version-fragile Focus database*.
+The plan front-loads the stable parts (the project skeleton and the wire contract),
+  then tackles parsing for one macOS version, then packaging/install, then compatibility breadth —
+  so each milestone delivers something a consumer or contributor can actually exercise,
+  and so a parser surprise on a future macOS version does not block the earlier milestones.
+
+## Milestones
+
+### M1 — Project skeleton and the `get_focus()` contract
+
+**In scope:**
+
+- Scaffold `macos-focus-gopher/` at the repo root: a Swift package and `.app` target,
+    a `mise.toml` exposing `build` / `test` / `lint` / `dependencies:check` / `dependencies:update` /
+    `ci`, wired into the root `mise.toml`, and CI invoking those Mise tasks.
+- Define the `FocusState` model and the line-delimited JSON request/response protocol over a
+    per-user Unix domain socket.
+- Implement `get_focus()` as a stub that returns a well-formed `FocusState`
+    (e.g. `ok: false`, `error: "macos_unsupported"`, or a fixed `unsupported` response) without
+    touching any database file.
+- Unit tests for `FocusState` encoding/decoding and the socket round-trip.
+
+**Deliverable:** the project builds, tests, and lints in CI;
+  a local client can connect to the running helper over the socket and receive a well-formed
+  (stubbed) `FocusState`.
+
+**Deferred to later milestones:** any real Focus parsing; packaging as an installed LaunchAgent.
+
+### M2 — Read-only Focus parsing on the current macOS version
+
+**In scope:**
+
+- macOS-version detection.
+- Parsing `Assertions.json` to determine whether an active Focus assertion exists,
+    and extracting the active Focus identifier when one does.
+- Parsing `ModeConfigurations.json` to map the identifier to a human-readable Focus name.
+- The compatibility-table lookup feeding `macos_compatibility`.
+- The full failure taxonomy with explicit `error` codes
+    (`focus_db_unreadable`, `focus_db_malformed`, `schema_unknown`, `macos_unsupported`,
+    `internal_error`), with a parse/schema failure never reported as `ok: true, focus_enabled: false`.
+- Fixture-based unit/integration tests: captured `Assertions.json` / `ModeConfigurations.json` shapes
+    for Focus-on, Focus-off, malformed, and unknown-schema cases, for the developer's macOS version.
+
+**Deliverable:** `get_focus()` returns a correct `FocusState` for Focus-on and Focus-off
+  on a known-supported macOS version, and an explicit error on unreadable/malformed/unknown data.
+
+**Deferred:** packaging/install; broad multi-version compatibility (only the developer's macOS version
+  is required to be fully exercised here, though the parser should be structured to add versions).
+
+### M3 — LaunchAgent packaging and install
+
+**In scope:**
+
+- A code-signed `.app` bundle, installed at the stable path, with a stable bundle identifier
+    and signing identity.
+- A per-user LaunchAgent plist and the install/uninstall flow that registers/unregisters it.
+- Socket lifecycle management (create on launch, clean up on exit, single-instance behavior).
+- Documentation of the macOS privacy permission the *helper* needs (Full Disk Access, if required)
+    and how to grant it — and confirmation that no client receives any permission as a result.
+- An end-to-end test: a client connects to the installed, running helper and receives a `FocusState`
+    (against a real macOS session where feasible; otherwise the real socket/process over fixture data).
+
+**Deliverable:** an installable helper that an unprivileged out-of-process client can query.
+
+**Deferred:** distribution mechanics beyond a local install (notarization, auto-update).
+
+### M4 — macOS compatibility breadth and contributor workflow
+
+**In scope:**
+
+- Seed the in-repo compatibility table: macOS 14 Sonoma — supported; macOS 15 Sequoia — supported;
+    macOS 26 Tahoe — unknown until tested.
+- Wire `macos_compatibility: unknown_but_working` (parsing succeeded on an unlisted version) with the
+    "please submit an issue or PR marking this version as compatible" `message`,
+    and the parse-failure `message` asking for an issue/PR with macOS version, helper version,
+    and error code.
+- Contributor documentation: how to add support for a new macOS version
+    (capture fixtures, add/adjust the parser if the schema changed, add the table entry, add tests).
+
+**Deliverable:** graceful, well-signposted behavior on macOS versions not yet on the supported list,
+  and a documented path for contributors to extend coverage.
+
+## Explicitly Deferred (out of scope for this plan)
+
+- A packaged client library (Swift, Python, or otherwise) for consumers — clients can speak the
+    documented socket protocol directly until there is a concrete need.
+- Distribution beyond a local install: notarization, a download/installer, auto-update.
+- Any operation beyond `get_focus()` — the narrow API is the point.
+
+## References
+
+- **Product Vision**: [macOS Focus Gopher](../product-vision/2026-05-12-macos-focus-gopher.md).
+- **Product Requirements**: [macOS Focus Gopher](../product-requirements/2026-05-12-macos-focus-gopher.md).
+- **Engineering Design**: [macOS Focus Gopher Engineering Design](../engineering-designs/2026-05-12-macos-focus-gopher.md).

--- a/design/delivery-plans/2026-05-12-macos-focus-gopher.md
+++ b/design/delivery-plans/2026-05-12-macos-focus-gopher.md
@@ -98,6 +98,13 @@ Per the [FDA / signing / distribution analysis](../analyses/2026-05-18-macos-fda
 - `README.md` updated to reflect "works on macOS 12–15, run from source", **including a clear
     "grant Full Disk Access to the helper" section** (the exact System Settings steps, and that the
     grant must be re-applied after each upgrade on the build-from-source channels).
+- **Dev docs — developing against the live Focus database (first milestone that reads the protected
+    files):** the contributor docs (`CONTRIBUTING.md` and/or a README "Developing" section) gain a
+    local-development guide: the fixture suite needs no Full Disk Access, and live-database smoke
+    testing needs FDA granted either to the developer's terminal/IDE (TCC responsible-process
+    attribution, for run-from-terminal iteration) or via a self-signed local code-signing certificate
+    so the grant survives rebuilds — per the
+    [FDA / signing / distribution analysis](../analyses/2026-05-18-macos-fda-distribution-signing.md).
 
 **Deliverable:** `get_focus()` (via socket or `focus-gopher`) returns a correct `FocusState` for
   Focus-on (manual and scheduled) and Focus-off on the supported macOS versions, and an explicit error
@@ -127,6 +134,13 @@ Per the [FDA / signing / distribution analysis](../analyses/2026-05-18-macos-fda
     is absent.
 - `README.md` updated with one-command install instructions and a short, deliberately slow/clear
     screen-recording GIF; a `man` page.
+- **Dev docs + tooling — the LaunchAgent shape (first milestone that builds a user LaunchAgent):**
+    because LaunchAgent-attributed access keys TCC to the helper binary's own (per-rebuild churning)
+    cdhash, the contributor docs document the self-signed local code-signing certificate workflow, and
+    the project ships a `mise`/build task that signs dev builds with that local certificate, so the
+    Full Disk Access grant persists across rebuilds during LaunchAgent testing without an Apple
+    Developer account — per the
+    [FDA / signing / distribution analysis](../analyses/2026-05-18-macos-fda-distribution-signing.md).
 
 **Deliverable:** an installable helper (`brew install …` from a tap, or `cargo install`) that an
   unprivileged out-of-process client can query, with honest install-and-use docs that set correct

--- a/design/delivery-plans/2026-05-12-macos-focus-gopher.md
+++ b/design/delivery-plans/2026-05-12-macos-focus-gopher.md
@@ -2,15 +2,26 @@
 
 ## Overview
 
-This plan sequences delivery of the [macOS Focus Gopher](../product-requirements/2026-05-12-macos-focus-gopher.md)
-  requirement into thin, independently-testable milestones,
-  per the [engineering design](../engineering-designs/2026-05-12-macos-focus-gopher.md).
+This plan sequences delivery of the
+  [macOS Focus Gopher](../product-requirements/2026-05-12-macos-focus-gopher.md) requirement into
+  thin, independently-testable milestones, per the
+  [engineering design](../engineering-designs/2026-05-12-macos-focus-gopher.md).
 
-The main delivery risk is the *undocumented, version-fragile Focus database*.
+The main delivery risk is the *undocumented, version-fragile Focus database*
+  (see the [format-stability analysis](../analyses/2026-05-12-macos-focus-db-format.md)).
 The plan front-loads the stable parts (the project skeleton and the wire contract),
-  then tackles parsing for one macOS version, then packaging/install, then compatibility breadth —
-  so each milestone delivers something a consumer or contributor can actually exercise,
-  and so a parser surprise on a future macOS version does not block the earlier milestones.
+  then tackles parsing for the verified macOS versions, then packaging/distribution, then compatibility
+  breadth and the agent ecosystem — so each milestone delivers something a consumer or contributor can
+  actually exercise, and so a parser surprise on a future macOS version does not block the earlier
+  milestones.
+
+## Delivery Conventions
+
+- **Each milestone ships as its own merged PR.**
+- **Public docs are built incrementally, alongside code, tests, and CI** — not deferred to the last
+    milestone. Every milestone PR leaves the project's `README.md` (and `--help`/`man` and the JSON
+    Schema, once they exist) accurate for the state of the project *at that point*, and the README
+    states plainly that the project is not yet ready for real use until it actually is.
 
 ## Milestones
 
@@ -18,81 +29,99 @@ The plan front-loads the stable parts (the project skeleton and the wire contrac
 
 **In scope:**
 
-- Scaffold `macos-focus-gopher/` at the repo root: a Swift package and `.app` target,
-    a `mise.toml` exposing `build` / `test` / `lint` / `dependencies:check` / `dependencies:update` /
-    `ci`, wired into the root `mise.toml`, and CI invoking those Mise tasks.
-- Define the `FocusState` model and the line-delimited JSON request/response protocol over a
-    per-user Unix domain socket.
+- Scaffold `macos-focus-gopher/` at the repo root: a Rust crate (the helper binary plus the
+    `focus-gopher` CLI wrapper) and the `.app` bundle packaging, a `mise.toml` exposing
+    `build` / `test` / `lint` / `dependencies:check` / `dependencies:update` / `ci`, wired into the
+    root `mise.toml`, and CI invoking those Mise tasks.
+- Define the `FocusState` model, publish its versioned **JSON Schema**, and define the line-delimited
+    JSON request/response protocol over a per-user Unix domain socket; the CLI wrapper relays
+    `get_focus()` over that socket and prints the result.
 - Implement `get_focus()` as a stub that returns a well-formed `FocusState`
-    (e.g. `ok: false`, `error: "macos_unsupported"`, or a fixed `unsupported` response) without
-    touching any database file.
-- Unit tests for `FocusState` encoding/decoding and the socket round-trip.
+    (e.g. `ok: false`, `error: "macos_unsupported"`) without touching any database file.
+- Unit tests for `FocusState` encoding/decoding, schema validation, and the socket/CLI round-trip.
+- Initial `README.md` (clearly marked early-development / not yet usable), an OSS `LICENSE` (MIT), and a
+    `CONTRIBUTING.md` stub that points at the repository-root `CONTRIBUTING.md` and these design docs.
 
 **Deliverable:** the project builds, tests, and lints in CI;
-  a local client can connect to the running helper over the socket and receive a well-formed
-  (stubbed) `FocusState`.
+  a local client can connect to the running helper over the socket — or run `focus-gopher` — and
+  receive a well-formed (stubbed) `FocusState` that validates against the published schema.
 
-**Deferred to later milestones:** any real Focus parsing; packaging as an installed LaunchAgent.
+**Deferred to later milestones:** any real Focus parsing; packaging as an installed LaunchAgent;
+  distribution.
 
-### M2 — Read-only Focus parsing on the current macOS version
+### M2 — Read-only Focus parsing on the verified macOS versions
 
 **In scope:**
 
 - macOS-version detection.
-- Parsing `Assertions.json` to determine whether an active Focus assertion exists,
-    and extracting the active Focus identifier when one does.
-- Parsing `ModeConfigurations.json` to map the identifier to a human-readable Focus name.
-- The compatibility-table lookup feeding `macos_compatibility`.
+- Parsing `Assertions.json` to determine whether a manually-activated Focus exists and extract its
+    identifier; consulting `ModeConfigurations.json` for schedule/automation-activated Foci; the
+    empty-file "Focus is off" case.
+- Mapping identifiers to human-readable Focus names via `ModeConfigurations.json` and a fixed table for
+    built-in Foci.
+- The compatibility-table lookup feeding `macos_compatibility`, seeded per the format-stability
+    analysis (the macOS 12–15 majors, verified against a current point release of each).
 - The full failure taxonomy with explicit `error` codes
     (`focus_db_unreadable`, `focus_db_malformed`, `schema_unknown`, `macos_unsupported`,
     `internal_error`), with a parse/schema failure never reported as `ok: true, focus_enabled: false`.
 - Fixture-based unit/integration tests: captured `Assertions.json` / `ModeConfigurations.json` shapes
-    for Focus-on, Focus-off, malformed, and unknown-schema cases, for the developer's macOS version.
+    for manual-Focus-on, scheduled-Focus-on, Focus-off (including the empty file), malformed, and
+    unknown-schema cases, per supported macOS major.
+- `README.md` updated to reflect "works on macOS 12–15, run from source"; first cut of `--help` output
+    with examples.
 
-**Deliverable:** `get_focus()` returns a correct `FocusState` for Focus-on and Focus-off
-  on a known-supported macOS version, and an explicit error on unreadable/malformed/unknown data.
+**Deliverable:** `get_focus()` returns a correct `FocusState` for Focus-on (manual and scheduled) and
+  Focus-off on the supported macOS versions, and an explicit error on unreadable/malformed/unknown data.
 
-**Deferred:** packaging/install; broad multi-version compatibility (only the developer's macOS version
-  is required to be fully exercised here, though the parser should be structured to add versions).
+**Deferred:** packaging/install; distribution; broader macOS version coverage; bundled agent skills.
 
-### M3 — LaunchAgent packaging and install
-
-**In scope:**
-
-- A code-signed `.app` bundle, installed at the stable path, with a stable bundle identifier
-    and signing identity.
-- A per-user LaunchAgent plist and the install/uninstall flow that registers/unregisters it.
-- Socket lifecycle management (create on launch, clean up on exit, single-instance behavior).
-- Documentation of the macOS privacy permission the *helper* needs (Full Disk Access, if required)
-    and how to grant it — and confirmation that no client receives any permission as a result.
-- An end-to-end test: a client connects to the installed, running helper and receives a `FocusState`
-    (against a real macOS session where feasible; otherwise the real socket/process over fixture data).
-
-**Deliverable:** an installable helper that an unprivileged out-of-process client can query.
-
-**Deferred:** distribution mechanics beyond a local install (notarization, auto-update).
-
-### M4 — macOS compatibility breadth and contributor workflow
+### M3 — Packaging, install, and distribution
 
 **In scope:**
 
-- Seed the in-repo compatibility table: macOS 14 Sonoma — supported; macOS 15 Sequoia — supported;
-    macOS 26 Tahoe — unknown until tested.
-- Wire `macos_compatibility: unknown_but_working` (parsing succeeded on an unlisted version) with the
-    "please submit an issue or PR marking this version as compatible" `message`,
-    and the parse-failure `message` asking for an issue/PR with macOS version, helper version,
-    and error code.
-- Contributor documentation: how to add support for a new macOS version
-    (capture fixtures, add/adjust the parser if the schema changed, add the table entry, add tests).
+- A code-signed and notarized `.app` bundle, installed at the stable path, with a stable bundle
+    identifier and signing identity.
+- A per-user LaunchAgent plist and the install/uninstall flow that registers/unregisters it; socket
+    lifecycle management (create on launch, clean up on exit, single-instance behavior).
+- A Homebrew formula (or tap) so the whole thing — bundle, LaunchAgent registration, `focus-gopher` on
+    `PATH` — installs with a single command.
+- Documentation of the macOS privacy permission the *helper* needs (Full Disk Access, if required) and
+    how to grant it — and confirmation that no client receives any permission as a result.
+- An end-to-end test: a client connects to the installed, running helper (and the CLI wrapper works)
+    and receives a `FocusState` (against a real macOS session where feasible; otherwise the real
+    socket/process over fixture data).
+- `README.md` updated with one-command install instructions and a short, deliberately slow/clear
+    screen-recording GIF; a `man` page.
 
-**Deliverable:** graceful, well-signposted behavior on macOS versions not yet on the supported list,
-  and a documented path for contributors to extend coverage.
+**Deliverable:** an installable helper (`brew install …`) that an unprivileged out-of-process client can
+  query, with honest install-and-use docs.
+
+**Deferred:** auto-update; broader macOS version coverage; bundled agent skills.
+
+### M4 — Compatibility breadth, the agent ecosystem, and docs polish
+
+**In scope:**
+
+- Maintain/expand the compatibility table: add macOS versions as they are verified (updating the
+    format-stability analysis as needed), wire `macos_compatibility: unknown_but_working` (parsing
+    succeeded on an unlisted version) with the "please submit an issue or PR" `message`, and the
+    parse-failure `message` asking for an issue/PR with macOS version, helper version, and error code.
+- Contributor documentation: how to add support for a new macOS version (capture fixtures, adjust the
+    parser if the schema changed, add the table entry, add tests).
+- Ship bundled **agent skills** plus a command that installs them into the user's home directory or a
+    specified project for common agent harnesses (e.g. Claude Code, Codex).
+- Final `README.md` / `--help` / `man` polish for both human and agent audiences (engaging content,
+    clear examples for every common operation, the JSON Schema referenced from the docs).
+
+**Deliverable:** graceful, well-signposted behavior on macOS versions not yet on the supported list, a
+  documented path for contributors to extend coverage, and a project that is easy for humans and agents
+  to discover, install, and use.
 
 ## Explicitly Deferred (out of scope for this plan)
 
-- A packaged client library (Swift, Python, or otherwise) for consumers — clients can speak the
-    documented socket protocol directly until there is a concrete need.
-- Distribution beyond a local install: notarization, a download/installer, auto-update.
+- A packaged client library (Rust, Python, or otherwise) for consumers — clients can speak the
+    documented socket protocol or use the CLI wrapper until there is a concrete need.
+- Distribution beyond Homebrew (e.g. a standalone downloadable installer) and auto-update.
 - Any operation beyond `get_focus()` — the narrow API is the point.
 
 ## References
@@ -100,3 +129,4 @@ The plan front-loads the stable parts (the project skeleton and the wire contrac
 - **Product Vision**: [macOS Focus Gopher](../product-vision/2026-05-12-macos-focus-gopher.md).
 - **Product Requirements**: [macOS Focus Gopher](../product-requirements/2026-05-12-macos-focus-gopher.md).
 - **Engineering Design**: [macOS Focus Gopher Engineering Design](../engineering-designs/2026-05-12-macos-focus-gopher.md).
+- **Analysis**: [macOS Focus Database Format and Stability](../analyses/2026-05-12-macos-focus-db-format.md).

--- a/design/delivery-plans/README.md
+++ b/design/delivery-plans/README.md
@@ -37,8 +37,9 @@ Simple, clearly-scoped requirements that fit comfortably in one PR do not need a
 - **Thin slices**: each milestone or PR delivers something independently usable or testable,
     not just an intermediate state that only makes sense in hindsight.
 - **Clear scope boundaries**: what is explicitly *in* each milestone, and what is deferred.
-- **Honest deferral**: if something feels nice-to-have, put it in a later milestone
-    (or drop it entirely) rather than bundling it into the first cut.
+- **Honest deferral**: separate work that is *required for the feature to function* from
+    *nice-to-have UX or polish*; sequence the latter into explicitly-optional later milestones
+    (that may never be reached) or drop it entirely, rather than bundling it into the first cut.
 - **Human decisions recorded**: the plan captures choices about sequencing and scope
     that aren't obvious from the requirements themselves.
 

--- a/design/engineering-designs/2026-05-12-macos-focus-gopher.md
+++ b/design/engineering-designs/2026-05-12-macos-focus-gopher.md
@@ -243,8 +243,10 @@ New codes may be added; existing codes are not repurposed.
     with Developer ID signing + notarization + a cask as an *optional* later enhancement (M6).
     Signing/notarization cannot grant Full Disk Access programmatically and cannot remove the one-time
     manual grant; their only benefits are that the grant *persists across upgrades* and that the OS
-    signposts the grant better — real but incremental UX wins that cost an Apple Developer Program
-    membership and release-pipeline complexity. The from-source path delivers full functionality now,
+    signposts the grant better (an out-of-band System Settings redirect dialog + FDA-pane pre-listing
+    for signed apps — a human-facing side channel the helper never sees, since the FDA-gated read still
+    returns the same permission error either way) — real but incremental UX wins that cost an Apple
+    Developer Program membership and release-pipeline complexity. The from-source path delivers full functionality now,
     at the cost of the user re-granting Full Disk Access on each upgrade, which the explicit
     `focus_permission_denied` code, the actionable message, and the docs are designed to make
     painless. See the

--- a/design/engineering-designs/2026-05-12-macos-focus-gopher.md
+++ b/design/engineering-designs/2026-05-12-macos-focus-gopher.md
@@ -131,9 +131,7 @@ New codes may be added; existing codes are not repurposed.
 ## Configuration
 
 - **Install path:** `/Applications/FocusGopher.app` (stable; updated infrequently).
-- **Bundle identifier:** a reverse-DNS identifier under the org's domain
-    (exact value — e.g. `family.justdavis.FocusGopher` — is an implementation detail to settle
-    when the project is scaffolded; once chosen it is stable).
+- **Bundle identifier:** `justdavis.FocusGopher` (stable once shipped).
 - **LaunchAgent plist:** `~/Library/LaunchAgents/<bundle-id>.plist`, registering the helper to run
     in the user's session; installed/removed by the helper's install/uninstall flow.
 - **Socket path:** a per-user, user-only-permissioned path (e.g. under the user's

--- a/design/engineering-designs/2026-05-12-macos-focus-gopher.md
+++ b/design/engineering-designs/2026-05-12-macos-focus-gopher.md
@@ -95,9 +95,10 @@ A single fixed-schema object whose shape **mirrors the helper's internal strongl
 Shared fields, always present:
 
 - `macos_version` (string) — the detected macOS version (e.g. `"15.5"`).
-- `macos_compatibility` (enum) — `supported` | `unknown_but_working` | `unknown` | `unsupported`.
-- `message` (string, optional) — human-readable guidance; omitted when there is none,
-    and never used for program logic.
+- `macos_compatibility` — a tagged enum: `supported`, `unsupported`, or `unknown` (the version is on
+    neither list). The `unknown` variant carries a `message` asking the user to report whether Focus
+    parsing worked on this version; whether it actually *did* work is conveyed by the `outcome`
+    (`determined` vs. `failed`), not by this field.
 
 Plus exactly one **outcome**, an externally-tagged discriminated union — the `Result`/`Option` plumbing
   is hidden behind domain-named keys rather than serialized as Rust's `Ok`/`Err`/`null`:
@@ -108,22 +109,29 @@ Plus exactly one **outcome**, an externally-tagged discriminated union — the `
       with `focus_name_unresolved`, not as a success — see the error taxonomy below).
   - `focus_off` — no Focus is active (an empty object).
 - `failed` — the helper could not determine the state. Carries a stable machine-readable `error` code
-    (see the error taxonomy below).
+    (see the error taxonomy below) plus a human-readable `message` with guidance for that error (the
+    FDA-grant instructions for `focus_permission_denied`, a "file an issue/PR" nudge otherwise).
 
 The internal Rust model the wire mirrors:
 
 ```rust
 struct FocusState {
     macos_version: String,
-    macos_compatibility: MacosCompat,
-    message: Option<String>,          // #[serde(skip_serializing_if = "Option::is_none")]
+    macos_compatibility: MacosCompatibility,
     outcome: Outcome,                 // #[serde(flatten)]
+}
+
+#[serde(rename_all = "snake_case")]   // externally tagged: "supported" | "unsupported" | "unknown"
+enum MacosCompatibility {
+    Supported,
+    Unsupported,
+    Unknown { message: String },
 }
 
 #[serde(rename_all = "snake_case")]   // externally tagged: "determined" | "failed"
 enum Outcome {
     Determined(Focus),
-    Failed { error: ErrorCode },
+    Failed { error: ErrorCode, message: String },
 }
 
 #[serde(rename_all = "snake_case")]   // externally tagged: "focus_on" | "focus_off"
@@ -151,15 +159,15 @@ Why this shape rather than a flat object of nullable siblings: the helper has no
 { "macos_version": "15.5", "macos_compatibility": "supported",
   "determined": { "focus_off": {} } }
 
-// (c) determined on an unknown-but-working macOS version
-{ "macos_version": "26.0", "macos_compatibility": "unknown_but_working",
-  "message": "Focus parsing appears to work, but this macOS version is not on the known-supported list. Please submit an issue or PR marking macOS 26.0 as compatible if this looks right.",
+// (c) determined on an unknown (unlisted) macOS version — the unknown variant carries the report message
+{ "macos_version": "26.0",
+  "macos_compatibility": { "unknown": { "message": "macOS 26.0 is not on the known-supported list. Please file an issue or PR reporting whether Focus parsing works here, so it can be added." } },
   "determined": { "focus_on": { "name": "Do Not Disturb" } } }
 
-// (d) failure (here: an active Focus whose name could not be resolved)
-{ "macos_version": "26.0", "macos_compatibility": "unknown",
-  "message": "A Focus appears active but its name could not be resolved. Please file an issue or PR with your macOS version, helper version, and this error code.",
-  "failed": { "error": "focus_name_unresolved" } }
+// (d) failure — the failed variant carries the guidance message (here, FDA remediation)
+{ "macos_version": "15.5", "macos_compatibility": "supported",
+  "failed": { "error": "focus_permission_denied",
+    "message": "Full Disk Access is required. Grant it to /Applications/FocusGopher.app under System Settings > Privacy & Security > Full Disk Access, then retry." } }
 ```
 
 ### Retrieval pipeline
@@ -178,9 +186,11 @@ Why this shape rather than a flat object of nullable siblings: the helper has no
     mapped to a name, return `failed` with `focus_name_unresolved` — in normal operation an active Focus
     is always nameable, so this signals a schema/coverage gap, not a steady-state success.
 9. If parsing succeeded but the macOS version is not on the known-supported list:
-    set `macos_compatibility: unknown_but_working` and the corresponding `message`.
+    set `macos_compatibility` to the `unknown` variant, carrying a `message` asking the user to report
+    whether parsing worked (independent of the outcome).
 10. If any step fails (permission-denied, missing/unreadable/malformed/partially-written file, or
-    unrecognized schema): return `failed` with an explicit `error` code, never a `determined` result.
+    unrecognized schema): return `failed` with an explicit `error` code and a guidance `message`, never
+    a `determined` result.
 
 The parser is **versioned and swappable**: the macOS Focus database format is undocumented and may
   change between releases, so the parsing logic is internal and may be reorganized per macOS version
@@ -211,7 +221,8 @@ New codes may be added; existing codes are not repurposed.
 
 `focus_permission_denied` is a distinct, first-class code because Full Disk Access can never be granted
   programmatically — it is always a manual System Settings step, and on the unsigned/from-source
-  channels it must be re-applied after every upgrade. Its `message` is therefore *actionable*: the
+  channels it must be re-applied after every upgrade. The `failed` variant's `message` is therefore
+  *actionable* text (no structured `grant_path` field — that would be detail nobody asked for): the
   *canonical resolved* helper binary path to add (cargo and Homebrew both symlink into `bin/`, and TCC
   matches the real binary), plus the
   `x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles` deep link. A missing FDA
@@ -341,7 +352,8 @@ New codes may be added; existing codes are not repurposed.
 - The helper exposes only a narrow read-only API (`get_focus()`), and no arbitrary filesystem,
     shell, Shortcut, or AppleScript access.
 - Rebuilding or upgrading the agent does not break the helper's TCC permissions.
-- The helper distinguishes *no Focus*, *active Focus* (named or unnamed), and *error* states.
+- The helper distinguishes *no Focus*, *active Focus* (always named), and *error* states (an
+    active-but-unnameable Focus is an error, `focus_name_unresolved`).
 - The helper reports known/unknown macOS compatibility.
 - The helper never exposes arbitrary filesystem, shell, Shortcut, or AppleScript access.
 - The parser correctly handles fixture databases for each supported macOS major version

--- a/design/engineering-designs/2026-05-12-macos-focus-gopher.md
+++ b/design/engineering-designs/2026-05-12-macos-focus-gopher.md
@@ -45,8 +45,9 @@ The Focus Gopher solves this by being a small, stable-identity broker:
     the current user only.
 - **Unix domain socket** for client IPC, created in a per-user, user-only-permissioned location,
     plus a **thin CLI wrapper** (`focus-gopher`) that connects to that socket, performs `get_focus()`,
-    and prints the resulting `FocusState` as JSON, exiting non-zero when `ok` is `false` — so callers
-    can use whichever they prefer, and shell scripts can branch on the exit code without parsing JSON.
+    and prints the resulting `FocusState` as JSON, exiting non-zero when the outcome is `failed` — so
+    callers can use whichever they prefer, and shell scripts can branch on the exit code without parsing
+    JSON.
     No network listener is opened.
 - **A small line-delimited JSON request/response protocol** over that socket:
     the client sends a fixed request, the helper replies with one `FocusState` JSON object.
@@ -85,46 +86,80 @@ The helper owns the macOS-specific access and is the only component that touches
 
 ### `FocusState` data model
 
-A single, flat, fixed-schema object, deliberately separating orthogonal facts so consumers never have
-  to guess (see
-  [Clear, Unambiguous, Easily-Parsed Data Models](../engineering-principles/2026-05-12-clear-data-models.md)):
+A single fixed-schema object whose shape **mirrors the helper's internal strongly-typed model** rather
+  than flattening it onto the wire — so invalid combinations are unrepresentable rather than merely
+  discouraged, and there is no divergent hand-maintained projection between the Rust types and the JSON
+  (see [the JSON-shape analysis](../analyses/2026-05-12-focus-state-json-shape.md) and
+  [Clear, Unambiguous, Easily-Parsed Data Models](../engineering-principles/2026-05-12-clear-data-models.md)).
 
-- `ok` (bool) — did the helper determine the Focus state?
-- `focus_enabled` (bool?) — is a Focus active? `null` only when `ok` is `false`.
-- `focus_name` (string?) — the human-readable Focus name; `null` when Focus is off,
-    when the name could not be resolved, or when `ok` is `false`.
+Shared fields, always present:
+
 - `macos_version` (string) — the detected macOS version (e.g. `"15.5"`).
 - `macos_compatibility` (enum) — `supported` | `unknown_but_working` | `unknown` | `unsupported`.
-- `message` (string?) — human-readable guidance only; never used for program logic.
-- `error` (string) — present on failures; a stable machine-readable code (see error taxonomy below).
+- `message` (string, optional) — human-readable guidance; omitted when there is none,
+    and never used for program logic.
 
-The wire form is flat: for a single small fixed-schema response, flat well-named fields parse most
-  easily, and well-regarded minimal JSON APIs lean flat at this size — the clarity comes from the
-  orthogonal fields, not from nesting. The helper's *internal* representation is a strongly-typed sum
-  type (roughly `Determined { focus: Option<FocusInfo>, … }` vs. `Failed { error, … }`) so invalid
-  combinations like "failed but Focus on" are unrepresentable in code; the flat JSON is a projection of
-  that, with the valid combinations enforced on the wire by the published JSON Schema rather than by
-  nesting (see [the JSON-shape analysis](../analyses/2026-05-12-focus-state-json-shape.md)). The four
-  response shapes:
+Plus exactly one **outcome**, an externally-tagged discriminated union — the `Result`/`Option` plumbing
+  is hidden behind domain-named keys rather than serialized as Rust's `Ok`/`Err`/`null`:
+
+- `determined` — the helper determined the state; its value is itself a tagged union:
+  - `focus_on` — a Focus is active; carries its human-readable `name` (always present: in normal
+      operation an active Focus is nameable, so an active-but-unnameable Focus is reported as `failed`
+      with `focus_name_unresolved`, not as a success — see the error taxonomy below).
+  - `focus_off` — no Focus is active (an empty object).
+- `failed` — the helper could not determine the state. Carries a stable machine-readable `error` code
+    (see the error taxonomy below).
+
+The internal Rust model the wire mirrors:
+
+```rust
+struct FocusState {
+    macos_version: String,
+    macos_compatibility: MacosCompat,
+    message: Option<String>,          // #[serde(skip_serializing_if = "Option::is_none")]
+    outcome: Outcome,                 // #[serde(flatten)]
+}
+
+#[serde(rename_all = "snake_case")]   // externally tagged: "determined" | "failed"
+enum Outcome {
+    Determined(Focus),
+    Failed { error: ErrorCode },
+}
+
+#[serde(rename_all = "snake_case")]   // externally tagged: "focus_on" | "focus_off"
+enum Focus {
+    FocusOn { name: String },
+    FocusOff {},
+}
+```
+
+Why this shape rather than a flat object of nullable siblings: the helper has no HTTP transport whose
+  status code could carry the success-vs-failure discriminant, so the body must — which puts us with
+  JSON-RPC / LSP, where the idiom is a structural discriminated union, not optional sibling fields. An
+  externally-tagged union is also serde's natural projection of the internal sum type, so the wire *is*
+  the serialized model (no divergent mapping layer to drift out of sync), and the published JSON Schema's
+  `oneOf` makes the illegal combinations unrepresentable on the wire as well. The CLI wrapper carries the
+  success/failure signal redundantly in its exit code (non-zero iff `failed`). See [the JSON-shape
+  analysis](../analyses/2026-05-12-focus-state-json-shape.md). The response shapes:
 
 ```jsonc
-// (a) success, Focus on
-{"ok": true, "focus_enabled": true, "focus_name": "Sleep",
- "macos_version": "15.5", "macos_compatibility": "supported", "message": null}
+// (a) determined, Focus on
+{ "macos_version": "15.5", "macos_compatibility": "supported",
+  "determined": { "focus_on": { "name": "Sleep" } } }
 
-// (b) success, no Focus on
-{"ok": true, "focus_enabled": false, "focus_name": null,
- "macos_version": "15.5", "macos_compatibility": "supported", "message": null}
+// (b) determined, Focus off
+{ "macos_version": "15.5", "macos_compatibility": "supported",
+  "determined": { "focus_off": {} } }
 
-// (c) success on an unknown-but-working macOS version
-{"ok": true, "focus_enabled": true, "focus_name": "Do Not Disturb",
- "macos_version": "26.0", "macos_compatibility": "unknown_but_working",
- "message": "This macOS version is not listed as known-supported, but Focus parsing appears to be working. Please submit an issue or PR marking macOS 26.0 as compatible if this result is correct."}
+// (c) determined on an unknown-but-working macOS version
+{ "macos_version": "26.0", "macos_compatibility": "unknown_but_working",
+  "message": "Focus parsing appears to work, but this macOS version is not on the known-supported list. Please submit an issue or PR marking macOS 26.0 as compatible if this looks right.",
+  "determined": { "focus_on": { "name": "Do Not Disturb" } } }
 
-// (d) failure
-{"ok": false, "focus_enabled": null, "focus_name": null,
- "macos_version": "26.0", "macos_compatibility": "unknown", "error": "focus_db_unreadable",
- "message": "Focus state could not be determined on this macOS version. Please file an issue or PR with your macOS version, helper version, and this error code."}
+// (d) failure (here: an active Focus whose name could not be resolved)
+{ "macos_version": "26.0", "macos_compatibility": "unknown",
+  "message": "A Focus appears active but its name could not be resolved. Please file an issue or PR with your macOS version, helper version, and this error code.",
+  "failed": { "error": "focus_name_unresolved" } }
 ```
 
 ### Retrieval pipeline
@@ -135,16 +170,17 @@ The wire form is flat: for a single small fixed-schema response, flat well-named
     An empty/near-empty file means no manually-activated Focus — a valid result, not an error.
 4. Consult `~/Library/DoNotDisturb/DB/ModeConfigurations.json` for a Focus activated by schedule or
     automation (reflected in the mode's trigger/enabled state rather than in `Assertions.json`).
-5. If no Focus is active by either path: return `ok: true`, `focus_enabled: false`, `focus_name: null`.
+5. If no Focus is active by either path: return `determined` → `focus_off`.
 6. If a Focus is active: extract the active Focus identifier.
 7. Map the identifier to a human-readable name via `ModeConfigurations.json` (and a fixed
     identifier→name table for built-in Foci).
-8. Return `ok: true`, `focus_enabled: true`, `focus_name: <name>`
-    (or `focus_name: null` if the identifier could not be mapped).
+8. Return `determined` → `focus_on` with `name: <name>`. If the active Focus's identifier cannot be
+    mapped to a name, return `failed` with `focus_name_unresolved` — in normal operation an active Focus
+    is always nameable, so this signals a schema/coverage gap, not a steady-state success.
 9. If parsing succeeded but the macOS version is not on the known-supported list:
     set `macos_compatibility: unknown_but_working` and the corresponding `message`.
 10. If any step fails (permission-denied, missing/unreadable/malformed/partially-written file, or
-    unrecognized schema): return `ok: false` with an explicit `error` code, never `focus_enabled: false`.
+    unrecognized schema): return `failed` with an explicit `error` code, never a `determined` result.
 
 The parser is **versioned and swappable**: the macOS Focus database format is undocumented and may
   change between releases, so the parsing logic is internal and may be reorganized per macOS version
@@ -163,6 +199,11 @@ A small, stable set of `error` codes, e.g.:
     reason other than a permission denial.
 - `focus_db_malformed` — a database file exists but is not parseable (truncated/partial write, invalid JSON).
 - `schema_unknown` — the file parsed as JSON but its structure does not match any known schema.
+- `focus_name_unresolved` — an active Focus was detected but its identifier could not be mapped to a
+    human-readable name. In normal operation an active Focus is always nameable, so this indicates a
+    schema/coverage gap (e.g. a new built-in identifier) worth reporting — not a steady-state result —
+    and the *name* is the primary thing consumers want, so a nameless "Focus is on" is treated as a
+    failure rather than a partial success.
 - `macos_unsupported` — the running macOS version is explicitly marked unsupported in the compatibility table.
 - `internal_error` — an unexpected helper-side failure.
 
@@ -174,7 +215,7 @@ New codes may be added; existing codes are not repurposed.
   *canonical resolved* helper binary path to add (cargo and Homebrew both symlink into `bin/`, and TCC
   matches the real binary), plus the
   `x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles` deep link. A missing FDA
-  grant is **never** collapsed into `ok: true, focus_enabled: false`. Detection is reactive: a denied
+  grant is **never** collapsed into a `determined` result. Detection is reactive: a denied
   `open()` on the protected, existing file returns `EPERM` (not `ENOENT`); because the protecting
   directory is itself TCC-gated, a would-be `ENOENT` can also surface as `EPERM` when unprivileged, so
   `EPERM` is treated as the dependable "denied" signal while `ENOENT` is only trusted as "absent" once
@@ -274,11 +315,18 @@ New codes may be added; existing codes are not repurposed.
     Chosen: `get_focus()` and nothing else. A general RPC surface (read arbitrary files, run shell,
     run shortcuts, run AppleScript) would re-create exactly the over-broad capability the design exists
     to avoid. See [Least Privilege](../engineering-principles/2026-05-12-least-privilege.md).
-- **A flat `FocusState` vs. a nested `focus`/`meta` envelope.**
-    Chosen: flat. It is one small fixed-schema response; an envelope mainly buys extensibility we don't
-    plan for (a second operation would be its own schema) plus a level of indirection every consumer
-    must walk. The success/failure signal lives in `ok` *and* in the CLI wrapper's exit code, so we get
-    the "proper status channel plus details in the body" pattern without an envelope. See
+- **An externally-tagged discriminated union mirroring the internal model vs. a flat object of nullable
+    siblings.**
+    Chosen: the externally-tagged union (`determined`/`failed`, with `focus_on`/`focus_off` inside
+    `determined`). A flat object (`ok`/`focus_enabled`/`focus_name`/`error` as nullable siblings) would
+    be serde's fragile *untagged* shape — variants told apart only by which optional fields happen to be
+    present — and a hand-maintained flattening that can drift from the Rust sum type. We have no HTTP
+    status code to carry the success-vs-failure discriminant, so (like JSON-RPC / LSP) the body carries
+    it structurally; the tagged union *is* the serialized internal sum type (no divergent mapping), makes
+    illegal states unrepresentable on the wire as well as in code, and is obvious to a human without
+    consulting the schema. The earlier flat recommendation leaned on REST APIs whose flatness is enabled
+    by an HTTP status discriminant we do not have. The success/failure signal is *also* carried in the
+    CLI wrapper's exit code (non-zero iff `failed`). See
     [the JSON-shape analysis](../analyses/2026-05-12-focus-state-json-shape.md).
 
 ## Success Criteria
@@ -287,8 +335,8 @@ New codes may be added; existing codes are not repurposed.
 - The agent itself has no Full Disk Access (or any other broad macOS privacy permission).
 - The helper has a stable macOS identity: a fixed install path and bundle ID on every channel, plus a
     stable Developer ID signing identity on the optional signed channel (M6).
-- A missing Full Disk Access grant is surfaced as the dedicated `focus_permission_denied` error with an
-    actionable, deep-linked `message`, never as `ok: true, focus_enabled: false`, and the docs explain
+- A missing Full Disk Access grant is surfaced as `failed` with the dedicated `focus_permission_denied`
+    error and an actionable, deep-linked `message`, never as a `determined` result, and the docs explain
     exactly how to grant (and, on from-source channels, re-grant) Full Disk Access.
 - The helper exposes only a narrow read-only API (`get_focus()`), and no arbitrary filesystem,
     shell, Shortcut, or AppleScript access.
@@ -299,8 +347,8 @@ New codes may be added; existing codes are not repurposed.
 - The parser correctly handles fixture databases for each supported macOS major version
     (manual-Focus-on, scheduled-Focus-on, Focus-off including the empty-file case, malformed, and
     unknown-schema fixtures), verified against a current point release of each.
-- A schema change or parse failure is surfaced as an explicit `error`, never as
-    `ok: true, focus_enabled: false`.
+- A schema change or parse failure is surfaced as `failed` with an explicit `error`, never as a
+    `determined` result.
 - A versioned JSON Schema for `FocusState` is published and the helper's output validates against it.
 - The helper installs with a single command via `cargo install` or Homebrew (formula/tap; the optional
     M6 cask for the signed build).
@@ -310,7 +358,7 @@ New codes may be added; existing codes are not repurposed.
 - **Product Vision**: [macOS Focus Gopher](../product-vision/2026-05-12-macos-focus-gopher.md).
 - **Product Requirements**: [macOS Focus Gopher](../product-requirements/2026-05-12-macos-focus-gopher.md).
 - **Analyses**: [macOS Focus Database Format and Stability](../analyses/2026-05-12-macos-focus-db-format.md);
-    [`FocusState` JSON Response Shape: Flat vs. Nested](../analyses/2026-05-12-focus-state-json-shape.md);
+    [`FocusState` JSON Response Shape: Flat vs. Tagged Union](../analyses/2026-05-12-focus-state-json-shape.md);
     [macOS Full Disk Access, Code Signing, and Distribution Channels](../analyses/2026-05-18-macos-fda-distribution-signing.md).
 - **Delivery Plan**: [macOS Focus Gopher Delivery Plan](../delivery-plans/2026-05-12-macos-focus-gopher.md).
 - **Engineering Principles**:

--- a/design/engineering-designs/2026-05-12-macos-focus-gopher.md
+++ b/design/engineering-designs/2026-05-12-macos-focus-gopher.md
@@ -28,10 +28,15 @@ The Focus Gopher solves this by being a small, stable-identity broker:
     helps with authoring and review.
 - **`serde` / `serde_json`** for the `FocusState` model and the socket protocol; a small blocking
     accept-loop for the socket server (no async runtime needed for a one-shot request/response).
-- **Per-user LaunchAgent** (`~/Library/LaunchAgents/<bundle-id>.plist`) — not a system LaunchDaemon.
-    Focus state is per-user, the database lives under the user's home directory,
-    and GUI-session context may matter; a LaunchAgent runs in the user's session with the user's view
-    of these files.
+- **LaunchAgent — not a system LaunchDaemon.** Focus state is per-user, the database lives under the
+    user's home directory, and GUI-session context may matter; a LaunchAgent runs *in each user's own
+    session* with that user's view of these files (one instance per logged-in user), whereas a
+    LaunchDaemon would run once as `root` and see the wrong (or no) user context. The plist location
+    sets *who it is installed for*, independent of that per-user execution: a shared/system install
+    (Homebrew, which has admin rights) places it in **`/Library/LaunchAgents/<bundle-id>.plist`** so it
+    runs for every user on the machine; a single-user developer install (e.g. `cargo install`, which is
+    per-user and has no admin rights) places it in **`~/Library/LaunchAgents/<bundle-id>.plist`** for
+    the current user only.
 - **Unix domain socket** for client IPC, created in a per-user, user-only-permissioned location,
     plus a **thin CLI wrapper** (`focus-gopher`) that connects to that socket, performs `get_focus()`,
     and prints the resulting `FocusState` as JSON, exiting non-zero when `ok` is `false` — so callers
@@ -87,10 +92,14 @@ A single, flat, fixed-schema object, deliberately separating orthogonal facts so
 - `message` (string?) — human-readable guidance only; never used for program logic.
 - `error` (string) — present on failures; a stable machine-readable code (see error taxonomy below).
 
-The model is flat: for a single small fixed-schema response, flat well-named fields parse most easily,
-  and well-regarded minimal JSON APIs lean flat at this size — the clarity comes from the orthogonal
-  fields, not from nesting (see
-  [the JSON-shape analysis](../analyses/2026-05-12-focus-state-json-shape.md)). The four response shapes:
+The wire form is flat: for a single small fixed-schema response, flat well-named fields parse most
+  easily, and well-regarded minimal JSON APIs lean flat at this size — the clarity comes from the
+  orthogonal fields, not from nesting. The helper's *internal* representation is a strongly-typed sum
+  type (roughly `Determined { focus: Option<FocusInfo>, … }` vs. `Failed { error, … }`) so invalid
+  combinations like "failed but Focus on" are unrepresentable in code; the flat JSON is a projection of
+  that, with the valid combinations enforced on the wire by the published JSON Schema rather than by
+  nesting (see [the JSON-shape analysis](../analyses/2026-05-12-focus-state-json-shape.md)). The four
+  response shapes:
 
 ```jsonc
 // (a) success, Focus on
@@ -156,8 +165,10 @@ New codes may be added; existing codes are not repurposed.
     formula/tap installs the bundle, registers the LaunchAgent, and links the `focus-gopher` CLI onto
     the user's `PATH`.
 - **Bundle identifier:** `justdavis.FocusGopher` (stable once shipped).
-- **LaunchAgent plist:** `~/Library/LaunchAgents/<bundle-id>.plist`, registering the helper to run
-    in the user's session; installed/removed by the install/uninstall flow.
+- **LaunchAgent plist:** `/Library/LaunchAgents/<bundle-id>.plist` for a shared/system install
+    (the Homebrew path — installs once for all users), or `~/Library/LaunchAgents/<bundle-id>.plist`
+    for a single-user developer install (e.g. `cargo install`); either way it registers the helper to
+    run in each user's session and is installed/removed by the install/uninstall flow.
 - **Socket path:** macOS has no `XDG_RUNTIME_DIR`-style blessed per-user socket directory (no
     `/run/user/<uid>/`), and `sockaddr_un.sun_path` is capped (~104 bytes), so this is a deliberate,
     deliberately-short choice. Preferred: a **`launchd`-managed socket** — declare a `Sockets` entry

--- a/design/engineering-designs/2026-05-12-macos-focus-gopher.md
+++ b/design/engineering-designs/2026-05-12-macos-focus-gopher.md
@@ -4,8 +4,10 @@
 
 Technical design for the **Focus Gopher**: a per-user macOS helper that reads the current Focus /
   Do Not Disturb state and exposes it to local clients through a single read-only operation.
-See [macOS Focus Gopher](../product-vision/2026-05-12-macos-focus-gopher.md) for product context
-  and [macOS Focus Gopher](../product-requirements/2026-05-12-macos-focus-gopher.md) for the requirement.
+See [macOS Focus Gopher](../product-vision/2026-05-12-macos-focus-gopher.md) for product context,
+  [macOS Focus Gopher](../product-requirements/2026-05-12-macos-focus-gopher.md) for the requirement,
+  and [macOS Focus Database Format and Stability](../analyses/2026-05-12-macos-focus-db-format.md)
+  for the research underpinning the database-reading approach.
 
 The technical problem: macOS Focus state is only available through privacy-gated mechanisms
   (an undocumented database under `~/Library` that generally requires Full Disk Access,
@@ -17,27 +19,34 @@ The Focus Gopher solves this by being a small, stable-identity broker:
 
 ## Technology Choices
 
-- **Swift**, building a native macOS `.app` bundle.
-    A code-signed `.app` is the natural unit for a stable bundle identifier, a stable signing identity,
-    and a TCC (privacy permission) grant that survives client rebuilds.
+- **Rust**, building a small headless helper binary plus a thin CLI wrapper.
+    The helper is packaged as a code-signed and notarized macOS `.app` bundle so it has a stable bundle
+    identifier, a stable signing identity, and a TCC (privacy permission) grant that attaches to the
+    bundle's code signature — none of which depends on the implementation language.
+    Because the helper is headless (no GUI), there is no AppKit/SwiftUI "native feel" to preserve,
+    so Rust costs us nothing here and is the team's preferred language for this kind of tool, which
+    helps with authoring and review.
+- **`serde` / `serde_json`** for the `FocusState` model and the socket protocol; a small blocking
+    accept-loop for the socket server (no async runtime needed for a one-shot request/response).
 - **Per-user LaunchAgent** (`~/Library/LaunchAgents/<bundle-id>.plist`) — not a system LaunchDaemon.
     Focus state is per-user, the database lives under the user's home directory,
     and GUI-session context may matter; a LaunchAgent runs in the user's session with the user's view
     of these files.
-- **Unix domain socket** for client IPC, created in a per-user, user-only-permissioned location.
-    Filesystem permissions restrict access to the logged-in user;
-    no network listener is opened.
+- **Unix domain socket** for client IPC, created in a per-user, user-only-permissioned location,
+    plus a **thin CLI wrapper** (`focus-gopher`) that connects to that socket, performs `get_focus()`,
+    and prints the resulting `FocusState` as JSON — so callers can use whichever they prefer.
+    No network listener is opened.
 - **A small line-delimited JSON request/response protocol** over that socket:
     the client sends a fixed request, the helper replies with one `FocusState` JSON object.
-    The schema is fixed and versioned; there is no general "send arbitrary command" path.
-- **Standard Swift test tooling** (`swift test` / `XCTest`) for unit and integration tests against
-    fixture database files, consistent with the "mocks are usually dumb" principle —
-    fixtures are real captured `Assertions.json` / `ModeConfigurations.json` shapes, not mocks.
-- **Monorepo conventions** (to honor when the project is later scaffolded, out of scope for this doc):
-    a `macos-focus-gopher/` directory at the repo root with a `mise.toml` exposing
-    `build` / `test` / `lint` / `dependencies:check` / `dependencies:update` / `ci` tasks,
-    wired into the root `mise.toml`'s `depends` arrays, with CI invoking the Mise tasks
-    (the same path developers run locally).
+    The schema is fixed, versioned, and published as a **JSON Schema** referenced from the docs;
+    there is no general "send arbitrary command" path.
+- **`cargo test`** for unit and integration tests against fixture database files, consistent with the
+    "mocks are usually dumb" principle — fixtures are real captured `Assertions.json` /
+    `ModeConfigurations.json` shapes, not mocks.
+- **Monorepo conventions:** a `macos-focus-gopher/` directory at the repo root with a `mise.toml`
+    exposing `build` / `test` / `lint` / `dependencies:check` / `dependencies:update` / `ci`, wired
+    into the root `mise.toml`'s `depends` arrays, with CI invoking those Mise tasks — the same path
+    developers run locally.
 
 ## Architecture
 
@@ -46,44 +55,48 @@ The Focus Gopher solves this by being a small, stable-identity broker:
 ```mermaid
 flowchart TB
     agent["Agent / OpenClaw<br/>(unprivileged client)"]
+    cli["focus-gopher CLI<br/>(thin wrapper)"]
     socket["local Unix domain socket"]
-    gopher["FocusGopher.app<br/>(per-user LaunchAgent)"]
+    gopher["FocusGopher.app helper<br/>(per-user LaunchAgent)"]
     parser["read-only Focus parser<br/>(versioned)"]
     db["~/Library/DoNotDisturb/DB/<br/>Assertions.json + ModeConfigurations.json"]
 
-    agent -->|get_focus request| socket --> gopher
-    gopher --> parser --> db
+    agent -->|get_focus request| socket
+    agent -.->|or runs| cli --> socket
+    socket --> gopher --> parser --> db
     db -.read-only.-> parser -.-> gopher
-    gopher -->|FocusState JSON| socket --> agent
+    gopher -->|FocusState JSON| socket
 ```
 
-The agent gets a narrow read-only API.
+The client gets a narrow read-only API — directly over the socket, or via the CLI wrapper.
 The helper owns the macOS-specific access and is the only component that touches the database files.
 
 ### `FocusState` data model
 
-A single fixed-schema object, deliberately separating orthogonal facts so consumers never have to guess
-  (see [Clear, Unambiguous, Easily-Parsed Data Models](../engineering-principles/2026-05-12-clear-data-models.md)):
+A single, flat, fixed-schema object, deliberately separating orthogonal facts so consumers never have
+  to guess (see
+  [Clear, Unambiguous, Easily-Parsed Data Models](../engineering-principles/2026-05-12-clear-data-models.md)):
 
 - `ok` (bool) — did the helper determine the Focus state?
 - `focus_enabled` (bool?) — is a Focus active? `null` only when `ok` is `false`.
 - `focus_name` (string?) — the human-readable Focus name; `null` when Focus is off,
     when the name could not be resolved, or when `ok` is `false`.
-- `macos_version` (string) — the detected macOS version (e.g. `"15.2"`).
+- `macos_version` (string) — the detected macOS version (e.g. `"15.5"`).
 - `macos_compatibility` (enum) — `supported` | `unknown_but_working` | `unknown` | `unsupported`.
 - `message` (string?) — human-readable guidance only; never used for program logic.
 - `error` (string) — present on failures; a stable machine-readable code (see error taxonomy below).
 
-The four response shapes:
+The model is intentionally flat: it is one small response, so flat well-named fields parse most easily;
+  the clarity comes from the orthogonal fields, not from nesting. The four response shapes:
 
 ```json
 // (a) success, Focus on
 {"ok": true, "focus_enabled": true, "focus_name": "Sleep",
- "macos_version": "15.2", "macos_compatibility": "supported", "message": null}
+ "macos_version": "15.5", "macos_compatibility": "supported", "message": null}
 
 // (b) success, no Focus on
 {"ok": true, "focus_enabled": false, "focus_name": null,
- "macos_version": "15.2", "macos_compatibility": "supported", "message": null}
+ "macos_version": "15.5", "macos_compatibility": "supported", "message": null}
 
 // (c) success on an unknown-but-working macOS version
 {"ok": true, "focus_enabled": true, "focus_name": "Do Not Disturb",
@@ -101,20 +114,26 @@ The four response shapes:
 1. Detect the macOS version.
 2. Look the version up in the compatibility table.
 3. Read `~/Library/DoNotDisturb/DB/Assertions.json`; determine whether an active Focus assertion exists.
-4. If no active assertion exists: return `ok: true`, `focus_enabled: false`, `focus_name: null`.
-5. If a Focus is active: extract the active Focus identifier.
-6. Read `~/Library/DoNotDisturb/DB/ModeConfigurations.json`; map the identifier to a human-readable name.
-7. Return `ok: true`, `focus_enabled: true`, `focus_name: <name>`
+    An empty/near-empty file means no manually-activated Focus — a valid result, not an error.
+4. Consult `~/Library/DoNotDisturb/DB/ModeConfigurations.json` for a Focus activated by schedule or
+    automation (reflected in the mode's trigger/enabled state rather than in `Assertions.json`).
+5. If no Focus is active by either path: return `ok: true`, `focus_enabled: false`, `focus_name: null`.
+6. If a Focus is active: extract the active Focus identifier.
+7. Map the identifier to a human-readable name via `ModeConfigurations.json` (and a fixed
+    identifier→name table for built-in Foci).
+8. Return `ok: true`, `focus_enabled: true`, `focus_name: <name>`
     (or `focus_name: null` if the identifier could not be mapped).
-8. If parsing succeeded but the macOS version is not on the known-supported list:
+9. If parsing succeeded but the macOS version is not on the known-supported list:
     set `macos_compatibility: unknown_but_working` and the corresponding `message`.
-9. If any step fails (missing/unreadable/malformed/partially-written file, or unrecognized schema):
+10. If any step fails (missing/unreadable/malformed/partially-written file, or unrecognized schema):
     return `ok: false` with an explicit `error` code, never `focus_enabled: false`.
 
-The parser is **versioned and swappable**: the macOS Focus database format is undocumented and changes
-  between releases, so the parsing logic is internal and may be reorganized per macOS version
+The parser is **versioned and swappable**: the macOS Focus database format is undocumented and may
+  change between releases, so the parsing logic is internal and may be reorganized per macOS version
   without changing the `get_focus() -> FocusState` interface.
 The stable interface is the contract; the schema is not.
+See [the format-stability analysis](../analyses/2026-05-12-macos-focus-db-format.md) for how the format
+  has held up across macOS 12–15 and what that means for the compatibility table.
 
 ### Error taxonomy
 
@@ -130,16 +149,22 @@ New codes may be added; existing codes are not repurposed.
 
 ## Configuration
 
-- **Install path:** `/Applications/FocusGopher.app` (stable; updated infrequently).
+- **Install path:** `/Applications/FocusGopher.app` (stable; updated infrequently). The Homebrew
+    formula/tap installs the bundle, registers the LaunchAgent, and links the `focus-gopher` CLI onto
+    the user's `PATH`.
 - **Bundle identifier:** `justdavis.FocusGopher` (stable once shipped).
 - **LaunchAgent plist:** `~/Library/LaunchAgents/<bundle-id>.plist`, registering the helper to run
-    in the user's session; installed/removed by the helper's install/uninstall flow.
+    in the user's session; installed/removed by the install/uninstall flow.
 - **Socket path:** a per-user, user-only-permissioned path (e.g. under the user's
     `~/Library/Application Support/<bundle-id>/` or a per-user temporary directory);
-    no network listener.
-- **macOS compatibility table:** maintained in the project repository as the source of truth,
-    seeded with macOS 14 Sonoma (supported), macOS 15 Sequoia (supported),
-    macOS 26 Tahoe (unknown until tested); the helper's `macos_compatibility` output is derived from it.
+    no network listener. The CLI wrapper knows this path.
+- **`FocusState` JSON Schema:** a versioned schema published in the repository and referenced by the
+    README and `--help`/`man` docs.
+- **macOS compatibility table:** maintained in the project repository as the source of truth, seeded
+    per [the format-stability analysis](../analyses/2026-05-12-macos-focus-db-format.md) — keyed by
+    macOS version string, with specific point releases or major-version wildcards (the latter only
+    where the analysis supports it and the parser is verified against a current point release);
+    the helper's `macos_compatibility` output is derived from it.
 - **Data sources (read-only):** `~/Library/DoNotDisturb/DB/Assertions.json` and
     `~/Library/DoNotDisturb/DB/ModeConfigurations.json` — undocumented macOS internals,
     subject to change across releases.
@@ -151,15 +176,28 @@ New codes may be added; existing codes are not repurposed.
     prompt-injectable agent has an enormous blast radius, and the grant is attached to an agent identity
     that churns (rebuilds, reinstalls, different launchers). The helper confines the powerful permission
     to a small, audited, stable binary and hands the agent only the answer.
-- **Per-user LaunchAgent vs. system LaunchDaemon.**
-    Chosen: LaunchAgent. Focus state is per-user; the database lives under `~/Library`;
-    a daemon would run outside the user's session and outside the user's view of those files.
+- **Per-user LaunchAgent serving a socket (+ thin CLI) vs. a plain CLI binary.**
+    Chosen: the LaunchAgent + socket, with the CLI as a thin client of it. A persistent agent process
+    is what carries the stable identity that owns the Full Disk Access grant; a freshly-invoked CLI
+    runs under the caller's responsible-process identity, and TCC/Full Disk Access for ad-hoc
+    command-line tools is unreliable. The thin CLI wrapper gives consumers command-line ergonomics
+    without giving up the stable-identity broker. The delivery plan includes an explicit checkpoint to
+    validate agent-integration ergonomics at the MVP and revisit this if the socket proves awkward.
 - **Reading the undocumented database vs. Shortcuts / AppleScript / a public API.**
-    Chosen: read the database, inside the helper. There is no stable public API for "current Focus state";
-    Shortcuts and AppleScript require Automation permissions and would widen the helper's capability
-    surface (it would have to be able to run shortcuts or scripts). Reading two JSON files read-only
-    is the narrowest mechanism, at the cost of being undocumented and version-fragile —
-    which the compatibility table and explicit-failure handling are designed to absorb.
+    Chosen: read the database, inside the helper. There is no stable public API for "current Focus
+    state"; Shortcuts and AppleScript require Automation permissions and would widen the helper's
+    capability surface (it would have to be able to run shortcuts or scripts), and a Shortcut-based
+    approach is also much harder to distribute and install (you can't `brew install` a Shortcut).
+    Reading two JSON files read-only is the narrowest mechanism, at the cost of being undocumented and
+    version-fragile — which the compatibility table, the format-stability analysis, and explicit-failure
+    handling are designed to absorb.
+- **Rust vs. Swift.**
+    Chosen: Rust. The helper is a headless background process, so there is no AppKit/SwiftUI "native
+    feel" at stake; a Rust binary packages into a code-signed/notarized `.app` and a LaunchAgent just
+    as well, and the TCC grant attaches to the bundle, not the language. Rust is the team's preferred
+    language for tools like this, which improves authoring and review. Swift would only win if deep
+    macOS-framework integration were needed — reading two JSON files does not require it. If a future
+    version needs significant native-framework work, this can be revisited.
 - **Fail explicitly on schema change vs. best-effort guessing.**
     Chosen: fail explicitly with an `error` code. A wrong guess that reports "no Focus is on"
     when parsing actually failed is a silent, dangerous error;
@@ -168,14 +206,10 @@ New codes may be added; existing codes are not repurposed.
     Chosen: `get_focus()` and nothing else. A general RPC surface (read arbitrary files, run shell,
     run shortcuts, run AppleScript) would re-create exactly the over-broad capability the design exists
     to avoid. See [Least Privilege](../engineering-principles/2026-05-12-least-privilege.md).
-- **Swift native `.app` vs. another language/runtime.**
-    Chosen: Swift. It is the path of least resistance for a code-signed macOS `.app` with a stable
-    bundle ID and TCC identity, and for any future need to touch macOS frameworks;
-    the helper is small enough that ecosystem concerns are minor.
 
 ## Success Criteria
 
-- An agent can retrieve the current Focus state via a single local call.
+- An agent can retrieve the current Focus state via a single local call (socket or CLI wrapper).
 - The agent itself has no Full Disk Access (or any other broad macOS privacy permission).
 - The helper has a stable macOS identity (fixed install path, bundle ID, signing identity).
 - The helper exposes only a narrow read-only API (`get_focus()`), and no arbitrary filesystem,
@@ -184,15 +218,19 @@ New codes may be added; existing codes are not repurposed.
 - The helper distinguishes *no Focus*, *active Focus* (named or unnamed), and *error* states.
 - The helper reports known/unknown macOS compatibility.
 - The helper never exposes arbitrary filesystem, shell, Shortcut, or AppleScript access.
-- The parser correctly handles fixture databases for each known-supported macOS version
-    (Focus-on, Focus-off, malformed, and unknown-schema fixtures).
+- The parser correctly handles fixture databases for each supported macOS major version
+    (manual-Focus-on, scheduled-Focus-on, Focus-off including the empty-file case, malformed, and
+    unknown-schema fixtures), verified against a current point release of each.
 - A schema change or parse failure is surfaced as an explicit `error`, never as
     `ok: true, focus_enabled: false`.
+- A versioned JSON Schema for `FocusState` is published and the helper's output validates against it.
+- The helper installs with a single Homebrew command.
 
 ## References
 
 - **Product Vision**: [macOS Focus Gopher](../product-vision/2026-05-12-macos-focus-gopher.md).
 - **Product Requirements**: [macOS Focus Gopher](../product-requirements/2026-05-12-macos-focus-gopher.md).
+- **Analysis**: [macOS Focus Database Format and Stability](../analyses/2026-05-12-macos-focus-db-format.md).
 - **Delivery Plan**: [macOS Focus Gopher Delivery Plan](../delivery-plans/2026-05-12-macos-focus-gopher.md).
 - **Engineering Principles**:
     [Least Privilege](../engineering-principles/2026-05-12-least-privilege.md);
@@ -200,5 +238,5 @@ New codes may be added; existing codes are not repurposed.
     [Strong Typing and Information Preservation](../engineering-principles/2026-01-07-strong-typing.md);
     [Comprehensive Error Modeling](../engineering-principles/2026-01-08-error-modeling.md);
     [Fail Fast and Loud](../engineering-principles/2026-01-09-fail-fast.md);
-    [YAGNI](../engineering-principles/2026-01-06-yagni.md) — e.g. no `normalized`/`source` fields
-    without a concrete consumer.
+    [YAGNI](../engineering-principles/2026-01-06-yagni.md) — e.g. no `normalized`/`source` fields,
+    and no list of all known-compatible macOS versions, without a concrete consumer.

--- a/design/engineering-designs/2026-05-12-macos-focus-gopher.md
+++ b/design/engineering-designs/2026-05-12-macos-focus-gopher.md
@@ -313,8 +313,8 @@ New codes may be added; existing codes are not repurposed.
     handling are designed to absorb.
 - **Rust vs. Swift.**
     Chosen: Rust. The helper is a headless background process, so there is no AppKit/SwiftUI "native
-    feel" at stake; a Rust binary packages into a code-signed/notarized `.app` and a LaunchAgent just
-    as well, and the TCC grant attaches to the bundle, not the language. Rust is the team's preferred
+    feel" at stake; a Rust binary packages into an `.app` and a LaunchAgent just as well (signed or
+    not), and the TCC grant attaches to the bundle, not the language. Rust is the team's preferred
     language for tools like this, which improves authoring and review. Swift would only win if deep
     macOS-framework integration were needed — reading two JSON files does not require it. If a future
     version needs significant native-framework work, this can be revisited.
@@ -357,8 +357,9 @@ New codes may be added; existing codes are not repurposed.
 - The helper reports known/unknown macOS compatibility.
 - The helper never exposes arbitrary filesystem, shell, Shortcut, or AppleScript access.
 - The parser correctly handles fixture databases for each supported macOS major version
-    (manual-Focus-on, scheduled-Focus-on, Focus-off including the empty-file case, malformed, and
-    unknown-schema fixtures), verified against a current point release of each.
+    (manual-Focus-on, scheduled-Focus-on, Focus-off including the empty-file case, malformed,
+    unknown-schema, permission-denied, and active-but-unnameable fixtures), verified against a current
+    point release of each.
 - A schema change or parse failure is surfaced as `failed` with an explicit `error`, never as a
     `determined` result.
 - A versioned JSON Schema for `FocusState` is published and the helper's output validates against it.

--- a/design/engineering-designs/2026-05-12-macos-focus-gopher.md
+++ b/design/engineering-designs/2026-05-12-macos-focus-gopher.md
@@ -92,7 +92,7 @@ The model is flat: for a single small fixed-schema response, flat well-named fie
   fields, not from nesting (see
   [the JSON-shape analysis](../analyses/2026-05-12-focus-state-json-shape.md)). The four response shapes:
 
-```json
+```jsonc
 // (a) success, Focus on
 {"ok": true, "focus_enabled": true, "focus_name": "Sleep",
  "macos_version": "15.5", "macos_compatibility": "supported", "message": null}
@@ -158,9 +158,15 @@ New codes may be added; existing codes are not repurposed.
 - **Bundle identifier:** `justdavis.FocusGopher` (stable once shipped).
 - **LaunchAgent plist:** `~/Library/LaunchAgents/<bundle-id>.plist`, registering the helper to run
     in the user's session; installed/removed by the install/uninstall flow.
-- **Socket path:** a per-user, user-only-permissioned path (e.g. under the user's
-    `~/Library/Application Support/<bundle-id>/` or a per-user temporary directory);
-    no network listener. The CLI wrapper knows this path.
+- **Socket path:** a deliberately short, per-user, user-only-permissioned path — short because
+    `sockaddr_un.sun_path` is capped (~104 bytes on macOS), so deep locations like
+    `~/Library/Application Support/<bundle-id>/…` (and `$TMPDIR`, which on macOS expands to a long
+    `/var/folders/…/T/` path) risk runtime bind/connect failures depending on the username. The
+    concrete path — e.g. a short fixed name such as `/tmp/justdavis.focusgopher.<uid>.sock`, with the
+    socket file created mode `0600` and the helper unlinking-then-binding and verifying owner/peer
+    identity on connect; or, preferably, a `Sockets` entry in the LaunchAgent plist so `launchd`
+    creates and owns the socket and passes the descriptor in — is fixed in M1. No network listener; the
+    CLI wrapper uses the same path.
 - **`FocusState` JSON Schema:** a versioned schema published in the repository and referenced by the
     README and `--help`/`man` docs.
 - **macOS compatibility table:** maintained in the project repository as the source of truth, seeded

--- a/design/engineering-designs/2026-05-12-macos-focus-gopher.md
+++ b/design/engineering-designs/2026-05-12-macos-focus-gopher.md
@@ -158,15 +158,20 @@ New codes may be added; existing codes are not repurposed.
 - **Bundle identifier:** `justdavis.FocusGopher` (stable once shipped).
 - **LaunchAgent plist:** `~/Library/LaunchAgents/<bundle-id>.plist`, registering the helper to run
     in the user's session; installed/removed by the install/uninstall flow.
-- **Socket path:** a deliberately short, per-user, user-only-permissioned path — short because
-    `sockaddr_un.sun_path` is capped (~104 bytes on macOS), so deep locations like
-    `~/Library/Application Support/<bundle-id>/…` (and `$TMPDIR`, which on macOS expands to a long
-    `/var/folders/…/T/` path) risk runtime bind/connect failures depending on the username. The
-    concrete path — e.g. a short fixed name such as `/tmp/justdavis.focusgopher.<uid>.sock`, with the
-    socket file created mode `0600` and the helper unlinking-then-binding and verifying owner/peer
-    identity on connect; or, preferably, a `Sockets` entry in the LaunchAgent plist so `launchd`
-    creates and owns the socket and passes the descriptor in — is fixed in M1. No network listener; the
-    CLI wrapper uses the same path.
+- **Socket path:** macOS has no `XDG_RUNTIME_DIR`-style blessed per-user socket directory (no
+    `/run/user/<uid>/`), and `sockaddr_un.sun_path` is capped (~104 bytes), so this is a deliberate,
+    deliberately-short choice. Preferred: a **`launchd`-managed socket** — declare a `Sockets` entry
+    (with `SockPathName`) in the LaunchAgent plist so `launchd` creates, owns, and tears down the
+    socket and hands the helper the descriptor via `launch_activate_socket()`, which also takes care of
+    socket lifecycle. Fallback if the helper manages it itself: **`$TMPDIR`** (i.e.
+    `confstr(_CS_DARWIN_USER_TEMP_DIR)`, e.g. `/var/folders/…/T/`) — the per-user, mode-`0700`,
+    user-owned directory that is the closest macOS analog to a per-user runtime dir — with a short
+    filename, since that path already eats most of the `sun_path` budget. (`~/Library/Application
+    Support/<bundle-id>/` is idiomatic for app *data* but is the deepest option and the most likely to
+    overflow the limit; a bare `/tmp/…` path is short but world-writable, so it needs unlink-then-bind
+    plus an owner check on both ends.) Whichever is chosen, the socket is user-only and the helper
+    verifies peer/owner identity on connect; the concrete path is pinned in M1. No network listener;
+    the CLI wrapper uses the same path.
 - **`FocusState` JSON Schema:** a versioned schema published in the repository and referenced by the
     README and `--help`/`man` docs.
 - **macOS compatibility table:** maintained in the project repository as the source of truth, seeded

--- a/design/engineering-designs/2026-05-12-macos-focus-gopher.md
+++ b/design/engineering-designs/2026-05-12-macos-focus-gopher.md
@@ -34,7 +34,8 @@ The Focus Gopher solves this by being a small, stable-identity broker:
     of these files.
 - **Unix domain socket** for client IPC, created in a per-user, user-only-permissioned location,
     plus a **thin CLI wrapper** (`focus-gopher`) that connects to that socket, performs `get_focus()`,
-    and prints the resulting `FocusState` as JSON — so callers can use whichever they prefer.
+    and prints the resulting `FocusState` as JSON, exiting non-zero when `ok` is `false` — so callers
+    can use whichever they prefer, and shell scripts can branch on the exit code without parsing JSON.
     No network listener is opened.
 - **A small line-delimited JSON request/response protocol** over that socket:
     the client sends a fixed request, the helper replies with one `FocusState` JSON object.
@@ -86,8 +87,10 @@ A single, flat, fixed-schema object, deliberately separating orthogonal facts so
 - `message` (string?) — human-readable guidance only; never used for program logic.
 - `error` (string) — present on failures; a stable machine-readable code (see error taxonomy below).
 
-The model is intentionally flat: it is one small response, so flat well-named fields parse most easily;
-  the clarity comes from the orthogonal fields, not from nesting. The four response shapes:
+The model is flat: for a single small fixed-schema response, flat well-named fields parse most easily,
+  and well-regarded minimal JSON APIs lean flat at this size — the clarity comes from the orthogonal
+  fields, not from nesting (see
+  [the JSON-shape analysis](../analyses/2026-05-12-focus-state-json-shape.md)). The four response shapes:
 
 ```json
 // (a) success, Focus on
@@ -206,6 +209,12 @@ New codes may be added; existing codes are not repurposed.
     Chosen: `get_focus()` and nothing else. A general RPC surface (read arbitrary files, run shell,
     run shortcuts, run AppleScript) would re-create exactly the over-broad capability the design exists
     to avoid. See [Least Privilege](../engineering-principles/2026-05-12-least-privilege.md).
+- **A flat `FocusState` vs. a nested `focus`/`meta` envelope.**
+    Chosen: flat. It is one small fixed-schema response; an envelope mainly buys extensibility we don't
+    plan for (a second operation would be its own schema) plus a level of indirection every consumer
+    must walk. The success/failure signal lives in `ok` *and* in the CLI wrapper's exit code, so we get
+    the "proper status channel plus details in the body" pattern without an envelope. See
+    [the JSON-shape analysis](../analyses/2026-05-12-focus-state-json-shape.md).
 
 ## Success Criteria
 
@@ -230,7 +239,8 @@ New codes may be added; existing codes are not repurposed.
 
 - **Product Vision**: [macOS Focus Gopher](../product-vision/2026-05-12-macos-focus-gopher.md).
 - **Product Requirements**: [macOS Focus Gopher](../product-requirements/2026-05-12-macos-focus-gopher.md).
-- **Analysis**: [macOS Focus Database Format and Stability](../analyses/2026-05-12-macos-focus-db-format.md).
+- **Analyses**: [macOS Focus Database Format and Stability](../analyses/2026-05-12-macos-focus-db-format.md);
+    [`FocusState` JSON Response Shape: Flat vs. Nested](../analyses/2026-05-12-focus-state-json-shape.md).
 - **Delivery Plan**: [macOS Focus Gopher Delivery Plan](../delivery-plans/2026-05-12-macos-focus-gopher.md).
 - **Engineering Principles**:
     [Least Privilege](../engineering-principles/2026-05-12-least-privilege.md);

--- a/design/engineering-designs/2026-05-12-macos-focus-gopher.md
+++ b/design/engineering-designs/2026-05-12-macos-focus-gopher.md
@@ -1,0 +1,206 @@
+# macOS Focus Gopher Engineering Design
+
+## Overview
+
+Technical design for the **Focus Gopher**: a per-user macOS helper that reads the current Focus /
+  Do Not Disturb state and exposes it to local clients through a single read-only operation.
+See [macOS Focus Gopher](../product-vision/2026-05-12-macos-focus-gopher.md) for product context
+  and [macOS Focus Gopher](../product-requirements/2026-05-12-macos-focus-gopher.md) for the requirement.
+
+The technical problem: macOS Focus state is only available through privacy-gated mechanisms
+  (an undocumented database under `~/Library` that generally requires Full Disk Access,
+  or Shortcuts/AppleScript which require Automation permissions),
+  and macOS attaches those permissions to a specific executable identity.
+The Focus Gopher solves this by being a small, stable-identity broker:
+  it holds whatever permission macOS requires, performs the privileged read itself,
+  and hands clients only a fixed-schema answer — never a general-purpose capability.
+
+## Technology Choices
+
+- **Swift**, building a native macOS `.app` bundle.
+    A code-signed `.app` is the natural unit for a stable bundle identifier, a stable signing identity,
+    and a TCC (privacy permission) grant that survives client rebuilds.
+- **Per-user LaunchAgent** (`~/Library/LaunchAgents/<bundle-id>.plist`) — not a system LaunchDaemon.
+    Focus state is per-user, the database lives under the user's home directory,
+    and GUI-session context may matter; a LaunchAgent runs in the user's session with the user's view
+    of these files.
+- **Unix domain socket** for client IPC, created in a per-user, user-only-permissioned location.
+    Filesystem permissions restrict access to the logged-in user;
+    no network listener is opened.
+- **A small line-delimited JSON request/response protocol** over that socket:
+    the client sends a fixed request, the helper replies with one `FocusState` JSON object.
+    The schema is fixed and versioned; there is no general "send arbitrary command" path.
+- **Standard Swift test tooling** (`swift test` / `XCTest`) for unit and integration tests against
+    fixture database files, consistent with the "mocks are usually dumb" principle —
+    fixtures are real captured `Assertions.json` / `ModeConfigurations.json` shapes, not mocks.
+- **Monorepo conventions** (to honor when the project is later scaffolded, out of scope for this doc):
+    a `macos-focus-gopher/` directory at the repo root with a `mise.toml` exposing
+    `build` / `test` / `lint` / `dependencies:check` / `dependencies:update` / `ci` tasks,
+    wired into the root `mise.toml`'s `depends` arrays, with CI invoking the Mise tasks
+    (the same path developers run locally).
+
+## Architecture
+
+### Component flow
+
+```mermaid
+flowchart TB
+    agent["Agent / OpenClaw<br/>(unprivileged client)"]
+    socket["local Unix domain socket"]
+    gopher["FocusGopher.app<br/>(per-user LaunchAgent)"]
+    parser["read-only Focus parser<br/>(versioned)"]
+    db["~/Library/DoNotDisturb/DB/<br/>Assertions.json + ModeConfigurations.json"]
+
+    agent -->|get_focus request| socket --> gopher
+    gopher --> parser --> db
+    db -.read-only.-> parser -.-> gopher
+    gopher -->|FocusState JSON| socket --> agent
+```
+
+The agent gets a narrow read-only API.
+The helper owns the macOS-specific access and is the only component that touches the database files.
+
+### `FocusState` data model
+
+A single fixed-schema object, deliberately separating orthogonal facts so consumers never have to guess
+  (see [Clear, Unambiguous, Easily-Parsed Data Models](../engineering-principles/2026-05-12-clear-data-models.md)):
+
+- `ok` (bool) — did the helper determine the Focus state?
+- `focus_enabled` (bool?) — is a Focus active? `null` only when `ok` is `false`.
+- `focus_name` (string?) — the human-readable Focus name; `null` when Focus is off,
+    when the name could not be resolved, or when `ok` is `false`.
+- `macos_version` (string) — the detected macOS version (e.g. `"15.2"`).
+- `macos_compatibility` (enum) — `supported` | `unknown_but_working` | `unknown` | `unsupported`.
+- `message` (string?) — human-readable guidance only; never used for program logic.
+- `error` (string) — present on failures; a stable machine-readable code (see error taxonomy below).
+
+The four response shapes:
+
+```json
+// (a) success, Focus on
+{"ok": true, "focus_enabled": true, "focus_name": "Sleep",
+ "macos_version": "15.2", "macos_compatibility": "supported", "message": null}
+
+// (b) success, no Focus on
+{"ok": true, "focus_enabled": false, "focus_name": null,
+ "macos_version": "15.2", "macos_compatibility": "supported", "message": null}
+
+// (c) success on an unknown-but-working macOS version
+{"ok": true, "focus_enabled": true, "focus_name": "Do Not Disturb",
+ "macos_version": "26.0", "macos_compatibility": "unknown_but_working",
+ "message": "This macOS version is not listed as known-supported, but Focus parsing appears to be working. Please submit an issue or PR marking macOS 26.0 as compatible if this result is correct."}
+
+// (d) failure
+{"ok": false, "focus_enabled": null, "focus_name": null,
+ "macos_version": "26.0", "macos_compatibility": "unknown", "error": "focus_db_unreadable",
+ "message": "Focus state could not be determined on this macOS version. Please file an issue or PR with your macOS version, helper version, and this error code."}
+```
+
+### Retrieval pipeline
+
+1. Detect the macOS version.
+2. Look the version up in the compatibility table.
+3. Read `~/Library/DoNotDisturb/DB/Assertions.json`; determine whether an active Focus assertion exists.
+4. If no active assertion exists: return `ok: true`, `focus_enabled: false`, `focus_name: null`.
+5. If a Focus is active: extract the active Focus identifier.
+6. Read `~/Library/DoNotDisturb/DB/ModeConfigurations.json`; map the identifier to a human-readable name.
+7. Return `ok: true`, `focus_enabled: true`, `focus_name: <name>`
+    (or `focus_name: null` if the identifier could not be mapped).
+8. If parsing succeeded but the macOS version is not on the known-supported list:
+    set `macos_compatibility: unknown_but_working` and the corresponding `message`.
+9. If any step fails (missing/unreadable/malformed/partially-written file, or unrecognized schema):
+    return `ok: false` with an explicit `error` code, never `focus_enabled: false`.
+
+The parser is **versioned and swappable**: the macOS Focus database format is undocumented and changes
+  between releases, so the parsing logic is internal and may be reorganized per macOS version
+  without changing the `get_focus() -> FocusState` interface.
+The stable interface is the contract; the schema is not.
+
+### Error taxonomy
+
+A small, stable set of `error` codes, e.g.:
+
+- `focus_db_unreadable` — a required database file is missing, permission-denied, or otherwise unreadable.
+- `focus_db_malformed` — a database file exists but is not parseable (truncated/partial write, invalid JSON).
+- `schema_unknown` — the file parsed as JSON but its structure does not match any known schema.
+- `macos_unsupported` — the running macOS version is explicitly marked unsupported in the compatibility table.
+- `internal_error` — an unexpected helper-side failure.
+
+New codes may be added; existing codes are not repurposed.
+
+## Configuration
+
+- **Install path:** `/Applications/FocusGopher.app` (stable; updated infrequently).
+- **Bundle identifier:** a reverse-DNS identifier under the org's domain
+    (exact value — e.g. `family.justdavis.FocusGopher` — is an implementation detail to settle
+    when the project is scaffolded; once chosen it is stable).
+- **LaunchAgent plist:** `~/Library/LaunchAgents/<bundle-id>.plist`, registering the helper to run
+    in the user's session; installed/removed by the helper's install/uninstall flow.
+- **Socket path:** a per-user, user-only-permissioned path (e.g. under the user's
+    `~/Library/Application Support/<bundle-id>/` or a per-user temporary directory);
+    no network listener.
+- **macOS compatibility table:** maintained in the project repository as the source of truth,
+    seeded with macOS 14 Sonoma (supported), macOS 15 Sequoia (supported),
+    macOS 26 Tahoe (unknown until tested); the helper's `macos_compatibility` output is derived from it.
+- **Data sources (read-only):** `~/Library/DoNotDisturb/DB/Assertions.json` and
+    `~/Library/DoNotDisturb/DB/ModeConfigurations.json` — undocumented macOS internals,
+    subject to change across releases.
+
+## Trade-offs
+
+- **A stable-identity helper vs. granting the agent Full Disk Access directly.**
+    Chosen: the helper. Granting Full Disk Access to an internet-connected, tool-using,
+    prompt-injectable agent has an enormous blast radius, and the grant is attached to an agent identity
+    that churns (rebuilds, reinstalls, different launchers). The helper confines the powerful permission
+    to a small, audited, stable binary and hands the agent only the answer.
+- **Per-user LaunchAgent vs. system LaunchDaemon.**
+    Chosen: LaunchAgent. Focus state is per-user; the database lives under `~/Library`;
+    a daemon would run outside the user's session and outside the user's view of those files.
+- **Reading the undocumented database vs. Shortcuts / AppleScript / a public API.**
+    Chosen: read the database, inside the helper. There is no stable public API for "current Focus state";
+    Shortcuts and AppleScript require Automation permissions and would widen the helper's capability
+    surface (it would have to be able to run shortcuts or scripts). Reading two JSON files read-only
+    is the narrowest mechanism, at the cost of being undocumented and version-fragile —
+    which the compatibility table and explicit-failure handling are designed to absorb.
+- **Fail explicitly on schema change vs. best-effort guessing.**
+    Chosen: fail explicitly with an `error` code. A wrong guess that reports "no Focus is on"
+    when parsing actually failed is a silent, dangerous error;
+    an explicit failure tells the consumer the state is unknown and tells the user to report it.
+- **A fixed-schema single operation vs. a general RPC surface.**
+    Chosen: `get_focus()` and nothing else. A general RPC surface (read arbitrary files, run shell,
+    run shortcuts, run AppleScript) would re-create exactly the over-broad capability the design exists
+    to avoid. See [Least Privilege](../engineering-principles/2026-05-12-least-privilege.md).
+- **Swift native `.app` vs. another language/runtime.**
+    Chosen: Swift. It is the path of least resistance for a code-signed macOS `.app` with a stable
+    bundle ID and TCC identity, and for any future need to touch macOS frameworks;
+    the helper is small enough that ecosystem concerns are minor.
+
+## Success Criteria
+
+- An agent can retrieve the current Focus state via a single local call.
+- The agent itself has no Full Disk Access (or any other broad macOS privacy permission).
+- The helper has a stable macOS identity (fixed install path, bundle ID, signing identity).
+- The helper exposes only a narrow read-only API (`get_focus()`), and no arbitrary filesystem,
+    shell, Shortcut, or AppleScript access.
+- Rebuilding or upgrading the agent does not break the helper's TCC permissions.
+- The helper distinguishes *no Focus*, *active Focus* (named or unnamed), and *error* states.
+- The helper reports known/unknown macOS compatibility.
+- The helper never exposes arbitrary filesystem, shell, Shortcut, or AppleScript access.
+- The parser correctly handles fixture databases for each known-supported macOS version
+    (Focus-on, Focus-off, malformed, and unknown-schema fixtures).
+- A schema change or parse failure is surfaced as an explicit `error`, never as
+    `ok: true, focus_enabled: false`.
+
+## References
+
+- **Product Vision**: [macOS Focus Gopher](../product-vision/2026-05-12-macos-focus-gopher.md).
+- **Product Requirements**: [macOS Focus Gopher](../product-requirements/2026-05-12-macos-focus-gopher.md).
+- **Delivery Plan**: [macOS Focus Gopher Delivery Plan](../delivery-plans/2026-05-12-macos-focus-gopher.md).
+- **Engineering Principles**:
+    [Least Privilege](../engineering-principles/2026-05-12-least-privilege.md);
+    [Clear, Unambiguous, Easily-Parsed Data Models](../engineering-principles/2026-05-12-clear-data-models.md);
+    [Strong Typing and Information Preservation](../engineering-principles/2026-01-07-strong-typing.md);
+    [Comprehensive Error Modeling](../engineering-principles/2026-01-08-error-modeling.md);
+    [Fail Fast and Loud](../engineering-principles/2026-01-09-fail-fast.md);
+    [YAGNI](../engineering-principles/2026-01-06-yagni.md) — e.g. no `normalized`/`source` fields
+    without a concrete consumer.

--- a/design/engineering-designs/2026-05-12-macos-focus-gopher.md
+++ b/design/engineering-designs/2026-05-12-macos-focus-gopher.md
@@ -20,9 +20,15 @@ The Focus Gopher solves this by being a small, stable-identity broker:
 ## Technology Choices
 
 - **Rust**, building a small headless helper binary plus a thin CLI wrapper.
-    The helper is packaged as a code-signed and notarized macOS `.app` bundle so it has a stable bundle
-    identifier, a stable signing identity, and a TCC (privacy permission) grant that attaches to the
-    bundle's code signature — none of which depends on the implementation language.
+    The helper is laid out as a macOS `.app` bundle with a stable install path and stable bundle
+    identifier, run as a per-user LaunchAgent — that bundle/LaunchAgent *architecture* is the unit the
+    macOS TCC (privacy permission) grant attaches to, and none of it depends on the implementation
+    language. **Developer ID signing and Apple notarization are a deferred, optional enhancement**
+    (delivery-plan M6): the earlier milestones ship build-from-source distribution where the binary is
+    unsigned/ad-hoc, so TCC keys the Full Disk Access grant off the binary's cdhash and the user
+    re-applies the grant on each upgrade; a Developer ID signature later makes the grant persist across
+    upgrades without changing the architecture. See the
+    [FDA / signing / distribution analysis](../analyses/2026-05-18-macos-fda-distribution-signing.md).
     Because the helper is headless (no GUI), there is no AppKit/SwiftUI "native feel" to preserve,
     so Rust costs us nothing here and is the team's preferred language for this kind of tool, which
     helps with authoring and review.
@@ -137,8 +143,8 @@ The wire form is flat: for a single small fixed-schema response, flat well-named
     (or `focus_name: null` if the identifier could not be mapped).
 9. If parsing succeeded but the macOS version is not on the known-supported list:
     set `macos_compatibility: unknown_but_working` and the corresponding `message`.
-10. If any step fails (missing/unreadable/malformed/partially-written file, or unrecognized schema):
-    return `ok: false` with an explicit `error` code, never `focus_enabled: false`.
+10. If any step fails (permission-denied, missing/unreadable/malformed/partially-written file, or
+    unrecognized schema): return `ok: false` with an explicit `error` code, never `focus_enabled: false`.
 
 The parser is **versioned and swappable**: the macOS Focus database format is undocumented and may
   change between releases, so the parsing logic is internal and may be reorganized per macOS version
@@ -151,7 +157,10 @@ See [the format-stability analysis](../analyses/2026-05-12-macos-focus-db-format
 
 A small, stable set of `error` codes, e.g.:
 
-- `focus_db_unreadable` — a required database file is missing, permission-denied, or otherwise unreadable.
+- `focus_permission_denied` — the Focus database exists but the helper was denied access to it
+    (an `EPERM` on `open()`), overwhelmingly meaning the helper has not been granted Full Disk Access.
+- `focus_db_unreadable` — a required database file is genuinely missing or otherwise unreadable for a
+    reason other than a permission denial.
 - `focus_db_malformed` — a database file exists but is not parseable (truncated/partial write, invalid JSON).
 - `schema_unknown` — the file parsed as JSON but its structure does not match any known schema.
 - `macos_unsupported` — the running macOS version is explicitly marked unsupported in the compatibility table.
@@ -159,12 +168,33 @@ A small, stable set of `error` codes, e.g.:
 
 New codes may be added; existing codes are not repurposed.
 
+`focus_permission_denied` is a distinct, first-class code because Full Disk Access can never be granted
+  programmatically — it is always a manual System Settings step, and on the unsigned/from-source
+  channels it must be re-applied after every upgrade. Its `message` is therefore *actionable*: the
+  *canonical resolved* helper binary path to add (cargo and Homebrew both symlink into `bin/`, and TCC
+  matches the real binary), plus the
+  `x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles` deep link. A missing FDA
+  grant is **never** collapsed into `ok: true, focus_enabled: false`. Detection is reactive: a denied
+  `open()` on the protected, existing file returns `EPERM` (not `ENOENT`); because the protecting
+  directory is itself TCC-gated, a would-be `ENOENT` can also surface as `EPERM` when unprivileged, so
+  `EPERM` is treated as the dependable "denied" signal while `ENOENT` is only trusted as "absent" once
+  access is confirmed (the benign "Focus off" state is empty *content*, not an absent file). See the
+  [FDA / signing / distribution analysis](../analyses/2026-05-18-macos-fda-distribution-signing.md).
+
 ## Configuration
 
-- **Install path:** `/Applications/FocusGopher.app` (stable; updated infrequently). The Homebrew
-    formula/tap installs the bundle, registers the LaunchAgent, and links the `focus-gopher` CLI onto
-    the user's `PATH`.
+- **Install path:** `/Applications/FocusGopher.app` (stable; updated infrequently). A build-from-source
+    install (the Homebrew formula/tap, or `cargo install`) installs the bundle, registers the
+    LaunchAgent, and links the `focus-gopher` CLI onto the user's `PATH`; the optional M6 cask installs
+    the prebuilt signed + notarized bundle at the same path.
 - **Bundle identifier:** `justdavis.FocusGopher` (stable once shipped).
+- **Full Disk Access & distribution:** the helper requires Full Disk Access to read the Focus
+    database. That grant is always a manual System Settings action (no programmatic prompt exists on
+    any channel), and on the unsigned build-from-source channels it is keyed to the binary's cdhash, so
+    it must be re-applied after each upgrade; Developer ID signing + notarization (M6, optional) makes
+    it persist across upgrades and improves first-run OS signposting. The install/uninstall flow and
+    docs surface the exact grant steps. See the
+    [FDA / signing / distribution analysis](../analyses/2026-05-18-macos-fda-distribution-signing.md).
 - **LaunchAgent plist:** `/Library/LaunchAgents/<bundle-id>.plist` for a shared/system install
     (the Homebrew path — installs once for all users), or `~/Library/LaunchAgents/<bundle-id>.plist`
     for a single-user developer install (e.g. `cargo install`); either way it registers the helper to
@@ -208,6 +238,17 @@ New codes may be added; existing codes are not repurposed.
     command-line tools is unreliable. The thin CLI wrapper gives consumers command-line ergonomics
     without giving up the stable-identity broker. The delivery plan includes an explicit checkpoint to
     validate agent-integration ergonomics at the MVP and revisit this if the socket proves awkward.
+- **Signed + notarized prebuilt distribution vs. build-from-source.**
+    Chosen: build-from-source (`cargo install`, Homebrew formula/tap) for the delivered milestones,
+    with Developer ID signing + notarization + a cask as an *optional* later enhancement (M6).
+    Signing/notarization cannot grant Full Disk Access programmatically and cannot remove the one-time
+    manual grant; their only benefits are that the grant *persists across upgrades* and that the OS
+    signposts the grant better — real but incremental UX wins that cost an Apple Developer Program
+    membership and release-pipeline complexity. The from-source path delivers full functionality now,
+    at the cost of the user re-granting Full Disk Access on each upgrade, which the explicit
+    `focus_permission_denied` code, the actionable message, and the docs are designed to make
+    painless. See the
+    [FDA / signing / distribution analysis](../analyses/2026-05-18-macos-fda-distribution-signing.md).
 - **Reading the undocumented database vs. Shortcuts / AppleScript / a public API.**
     Chosen: read the database, inside the helper. There is no stable public API for "current Focus
     state"; Shortcuts and AppleScript require Automation permissions and would widen the helper's
@@ -242,7 +283,11 @@ New codes may be added; existing codes are not repurposed.
 
 - An agent can retrieve the current Focus state via a single local call (socket or CLI wrapper).
 - The agent itself has no Full Disk Access (or any other broad macOS privacy permission).
-- The helper has a stable macOS identity (fixed install path, bundle ID, signing identity).
+- The helper has a stable macOS identity: a fixed install path and bundle ID on every channel, plus a
+    stable Developer ID signing identity on the optional signed channel (M6).
+- A missing Full Disk Access grant is surfaced as the dedicated `focus_permission_denied` error with an
+    actionable, deep-linked `message`, never as `ok: true, focus_enabled: false`, and the docs explain
+    exactly how to grant (and, on from-source channels, re-grant) Full Disk Access.
 - The helper exposes only a narrow read-only API (`get_focus()`), and no arbitrary filesystem,
     shell, Shortcut, or AppleScript access.
 - Rebuilding or upgrading the agent does not break the helper's TCC permissions.
@@ -255,14 +300,16 @@ New codes may be added; existing codes are not repurposed.
 - A schema change or parse failure is surfaced as an explicit `error`, never as
     `ok: true, focus_enabled: false`.
 - A versioned JSON Schema for `FocusState` is published and the helper's output validates against it.
-- The helper installs with a single Homebrew command.
+- The helper installs with a single command via `cargo install` or Homebrew (formula/tap; the optional
+    M6 cask for the signed build).
 
 ## References
 
 - **Product Vision**: [macOS Focus Gopher](../product-vision/2026-05-12-macos-focus-gopher.md).
 - **Product Requirements**: [macOS Focus Gopher](../product-requirements/2026-05-12-macos-focus-gopher.md).
 - **Analyses**: [macOS Focus Database Format and Stability](../analyses/2026-05-12-macos-focus-db-format.md);
-    [`FocusState` JSON Response Shape: Flat vs. Nested](../analyses/2026-05-12-focus-state-json-shape.md).
+    [`FocusState` JSON Response Shape: Flat vs. Nested](../analyses/2026-05-12-focus-state-json-shape.md);
+    [macOS Full Disk Access, Code Signing, and Distribution Channels](../analyses/2026-05-18-macos-fda-distribution-signing.md).
 - **Delivery Plan**: [macOS Focus Gopher Delivery Plan](../delivery-plans/2026-05-12-macos-focus-gopher.md).
 - **Engineering Principles**:
     [Least Privilege](../engineering-principles/2026-05-12-least-privilege.md);

--- a/design/engineering-principles/2026-01-07-strong-typing.md
+++ b/design/engineering-principles/2026-01-07-strong-typing.md
@@ -4,6 +4,10 @@
 
 Model data using strongly-typed structures that preserve all available information.
 Avoid lossy transformations or premature data simplification.
+This holds at boundaries too: a serialized or stored representation should preserve the type's
+  *guarantees*, not only its data — encode sum types as tagged unions (a discriminant plus that
+  variant's fields) that mirror the in-memory type, never as co-present nullable fields, so illegal
+  states stay unrepresentable on the wire as they are in code.
 
 ## Rationale
 
@@ -25,14 +29,21 @@ Avoid lossy transformations or premature data simplification.
 - Discarding error details when converting between error types.
 - Truncating timestamps or numeric precision "because we don't need it yet."
 - Using `bool` when the domain has three or more states.
+- Flattening an internal sum type onto the wire as independently-nullable fields, so the serialized
+    form can express combinations the in-memory type cannot — and a hand-maintained reshape between
+    layers can drift out of sync with the domain model.
 
 ## When to Break This Rule
 
 - Performance-critical code paths where type information incurs measurable overhead.
-- External API boundaries that require specific formats (but preserve full info internally).
+- External API boundaries that require a *specific wire format* — adapt the encoding, but still
+    preserve the type's guarantees per the principle above (tagged unions; never flatten a sum type
+    into nullable siblings), not merely its information.
 - Display/presentation logic where simplification aids user understanding (but keep full data in model).
 
 ## Relationship to Other Principles
 
 - Enables **comprehensive error modeling** - types make error cases explicit.
 - Supports **fail fast and loud** - type mismatches are caught at compile time.
+- Underpins **clear, unambiguous, easily-parsed data models** - tagged unions at the boundary are how
+    "separate orthogonal facts, never collapse states" is enforced on the wire.

--- a/design/engineering-principles/2026-01-08-error-modeling.md
+++ b/design/engineering-principles/2026-01-08-error-modeling.md
@@ -20,6 +20,9 @@ Function and service results should expose all failure modes to enable debugging
 - Include context in errors: what operation failed, with what inputs, and why.
 - Log errors with full context before returning them.
 - Chain errors to preserve original cause (e.g., Rust's `context()` or Swift's `NSError.userInfo`).
+- Errors that cross a *published boundary* (a wire protocol or public API) are enumerated, serializable
+    domain types that callers match on — distinct from internal propagation errors, which may be
+    dynamic (e.g., Rust's `anyhow`) since nothing downstream matches on them.
 
 **Bad (suppresses or loses error information):**
 - Using `unwrap()` in Rust or force-unwrapping (`!`) in Swift without clear justification.

--- a/design/engineering-principles/2026-05-12-clear-data-models.md
+++ b/design/engineering-principles/2026-05-12-clear-data-models.md
@@ -7,6 +7,9 @@ Design data models — especially those that cross a process, network, or API bo
   no overloaded fields, and a clear separation of orthogonal facts so a consumer never has to guess.
 In particular, distinguish "the operation failed" from "the operation succeeded and the answer is
   negative"; never collapse genuinely distinct states into a single ambiguous value.
+Frame the model around the consumer's primary decision: surface the states a consumer actually acts on,
+  and let that goal classify edge cases rather than minting a new state for every technical
+  possibility.
 
 ## Rationale
 
@@ -42,7 +45,8 @@ In particular, distinguish "the operation failed" from "the operation succeeded 
 - Adding speculative fields (e.g. `normalized`, `source`) with no concrete consumer — clarity is not
     maximalism, and unused fields are just more surface to misinterpret.
 - Reusing one field for different meanings depending on another field's value, without that being an
-    explicit, documented tagged union.
+    explicit, documented tagged union — which, at a boundary, must be encoded *as* a tagged union (see
+    [Strong Typing and Information Preservation](2026-01-07-strong-typing.md)), not as nullable siblings.
 
 ## When to Break This Rule
 

--- a/design/engineering-principles/2026-05-12-clear-data-models.md
+++ b/design/engineering-principles/2026-05-12-clear-data-models.md
@@ -21,13 +21,15 @@ In particular, distinguish "the operation failed" from "the operation succeeded 
 
 **Good (clear-data-model-compliant):**
 
-- A response that separates orthogonal facts into their own fields — e.g. `FocusState` with
-    `ok` (did we determine the state?), `focus_enabled` (is a Focus on?), `focus_name` (do we have a
-    name?), and `macos_compatibility` (is this OS version supported?) — each with documented null
-    semantics.
-- Returning `{"ok": false, "error": "schema_unknown"}` on a parse failure, rather than
-    `{"ok": true, "focus_enabled": false}`.
-- A `message` field that is explicitly human-only guidance, with all machine-relevant facts carried
+- A response that separates orthogonal facts and models its states as a tagged union — e.g.
+    `FocusState`, whose outcome is `determined` (itself `focus_on` with a `name`, or `focus_off`) or
+    `failed` (with an `error` code), alongside `macos_compatibility` (`supported` / `unsupported` /
+    `unknown`) — so each state is its own variant rather than a set of independently-nullable fields
+    that can combine into nonsense.
+- Returning `{"failed": {"error": "schema_unknown", …}}` on a parse failure, rather than a
+    `determined` → `focus_off` result that would disguise the failure as "no Focus is on".
+- A `message` field that is explicitly human-only guidance — attached to the variant that needs it
+    (e.g. `failed`, or the `unknown` compatibility variant) — with all machine-relevant facts carried
     in their own typed fields.
 - A fixed, documented schema for everything that crosses the boundary.
 

--- a/design/engineering-principles/2026-05-12-clear-data-models.md
+++ b/design/engineering-principles/2026-05-12-clear-data-models.md
@@ -44,8 +44,6 @@ In particular, distinguish "the operation failed" from "the operation succeeded 
 
 ## When to Break This Rule
 
-- Throwaway internal scripts where the producer and the consumer are the same code and always change
-    together — there is no boundary to be careful at.
 - Cases where you must conform to an external format that is itself ambiguous — wrap and normalize it
     into a clear model at the boundary rather than propagating the ambiguity inward.
 

--- a/design/engineering-principles/2026-05-12-clear-data-models.md
+++ b/design/engineering-principles/2026-05-12-clear-data-models.md
@@ -1,0 +1,60 @@
+# Clear, Unambiguous, Easily-Parsed Data Models
+
+## Principle
+
+Design data models — especially those that cross a process, network, or API boundary —
+  to be unambiguous and trivial to parse: a fixed schema, explicit field semantics,
+  no overloaded fields, and a clear separation of orthogonal facts so a consumer never has to guess.
+In particular, distinguish "the operation failed" from "the operation succeeded and the answer is
+  negative"; never collapse genuinely distinct states into a single ambiguous value.
+
+## Rationale
+
+- An ambiguous model pushes interpretation logic — and its bugs — onto every consumer.
+- Conflating "no result", "empty result", and "error" leads to silent failures:
+    a parse failure that looks like "nothing here" is acted on as if nothing were wrong.
+- When orthogonal facts get their own fields, consumer logic collapses to a simple decision tree,
+    and the model documents itself.
+- Fixed schemas are easy to validate, version deliberately, and keep stable across releases.
+
+## Examples
+
+**Good (clear-data-model-compliant):**
+
+- A response that separates orthogonal facts into their own fields — e.g. `FocusState` with
+    `ok` (did we determine the state?), `focus_enabled` (is a Focus on?), `focus_name` (do we have a
+    name?), and `macos_compatibility` (is this OS version supported?) — each with documented null
+    semantics.
+- Returning `{"ok": false, "error": "schema_unknown"}` on a parse failure, rather than
+    `{"ok": true, "focus_enabled": false}`.
+- A `message` field that is explicitly human-only guidance, with all machine-relevant facts carried
+    in their own typed fields.
+- A fixed, documented schema for everything that crosses the boundary.
+
+**Bad (ambiguous or hard-to-parse models):**
+
+- A boolean that means "off OR we couldn't tell" — two different states, one value.
+- Reporting a failure as a successful negative result (silent failure).
+- Tunneling structured data through a free-text `message` (or an error string) that consumers must
+    pattern-match.
+- Adding speculative fields (e.g. `normalized`, `source`) with no concrete consumer — clarity is not
+    maximalism, and unused fields are just more surface to misinterpret.
+- Reusing one field for different meanings depending on another field's value, without that being an
+    explicit, documented tagged union.
+
+## When to Break This Rule
+
+- Throwaway internal scripts where the producer and the consumer are the same code and always change
+    together — there is no boundary to be careful at.
+- Cases where you must conform to an external format that is itself ambiguous — wrap and normalize it
+    into a clear model at the boundary rather than propagating the ambiguity inward.
+
+## Relationship to Other Principles
+
+- Builds on **strong typing and information preservation** — orthogonal facts get distinct, well-typed
+    fields instead of being squeezed into one stringly-typed value.
+- Reinforces **comprehensive error modeling** and **fail fast and loud** — "failed" is a first-class,
+    explicit state, never disguised as a benign result.
+- Pairs with **least privilege** — a single narrow operation naturally has a single clear response
+    schema.
+- Constrained by **YAGNI** — model the facts you actually have, not hypothetical ones.

--- a/design/engineering-principles/2026-05-12-least-privilege.md
+++ b/design/engineering-principles/2026-05-12-least-privilege.md
@@ -1,0 +1,57 @@
+# Least Privilege
+
+## Principle
+
+Grant every component the narrowest capability surface that does its job, and no more —
+  and treat this as especially load-bearing when the actor on the other side of an interface is
+  untrusted or only semi-trusted, such as an LLM/agent with internet access, arbitrary tool use,
+  plugins, and prompt-injection exposure.
+Prefer fixed-schema, single-purpose operations over general-purpose ones.
+When a component needs a powerful permission (filesystem access, OS privacy grants, network reach),
+  put it behind a small, stable-identity broker so the powerful permission attaches to the broker,
+  not to every consumer that wants the result.
+
+## Rationale
+
+- A smaller capability surface means a smaller blast radius when a consumer is compromised,
+    buggy, or manipulated.
+- Agents are a worst case: they execute attacker-influenced text, call arbitrary tools, and run from
+    churning identities — so any broad permission handed to an agent is both dangerous and fragile.
+- Brokering privileged access keeps OS permission grants (e.g. macOS TCC / Full Disk Access)
+    confined to a small, audited binary with a stable identity, instead of sprawling onto ephemeral or
+    rebuilt executables.
+- Narrow, fixed-schema APIs are easier to audit, test, reason about, and keep stable over time.
+
+## Examples
+
+**Good (least-privilege-compliant):**
+
+- A helper that exposes exactly one operation — `get_focus() -> FocusState` — and nothing else.
+- A service that reads one specific config file, rather than one that accepts an arbitrary path.
+- Putting Full Disk Access on a small, stable, code-signed helper that returns a fixed answer,
+    rather than on the agent that wants the answer.
+- Issuing a token scoped to exactly the resources and actions needed, with a short lifetime.
+
+**Bad (least-privilege violations):**
+
+- Granting Full Disk Access (or broad Automation/Accessibility permissions) directly to an agent process.
+- A "helper" that proxies `read_file(path)`, `run_shell(command)`, `run_shortcut(name)`,
+    or `run_osascript(script)` — that is a general-purpose capability, not a narrow one.
+- Adding a general "run arbitrary query" endpoint when callers only ever need a handful of fixed answers.
+- Reusing one broadly-scoped credential everywhere because minting narrower ones is mildly inconvenient.
+
+## When to Break This Rule
+
+- Genuine general-purpose tools whose entire point is breadth — a shell, a debugger, an admin console —
+    used by trusted operators who understand the power they hold.
+- Early prototypes where the only consumer is fully trusted first-party code and the cost of narrowing
+    later is low — but revisit this before any untrusted or third-party actor (especially an agent)
+    is introduced.
+
+## Relationship to Other Principles
+
+- Complements **YAGNI** — don't expose capabilities no one needs yet; a narrow API is also a smaller API.
+- Supports **comprehensive error modeling** and **fail fast and loud** — a narrow operation has a small,
+    well-defined error surface, so failures are easy to model and surface.
+- Reinforces **clear, unambiguous, easily-parsed data models** — a single fixed operation naturally
+    has a single fixed response schema.

--- a/design/product-requirements/2026-05-12-macos-focus-gopher.md
+++ b/design/product-requirements/2026-05-12-macos-focus-gopher.md
@@ -1,0 +1,162 @@
+---
+title: macOS Focus Gopher
+status: draft
+vision:
+  - 2026-05-12-macos-focus-gopher
+depends_on: []
+extends: []
+modifies: []
+replaces: []
+engineering_designs:
+  - 2026-05-12-macos-focus-gopher.md
+prs: []
+---
+
+# macOS Focus Gopher
+
+## Summary
+
+A per-user macOS helper that an unprivileged local client (e.g. an LLM/agent system) can query
+  to learn the current macOS Focus state, without the client process itself holding Full Disk Access
+  or any other broad macOS privacy permission.
+The helper is a code-signed `.app` with a stable identity, run as a per-user LaunchAgent,
+  exposing exactly one read-only operation over a local Unix domain socket:
+  `get_focus()`, returning a fixed-schema `FocusState`.
+The helper performs the privileged, undocumented Focus-database read itself,
+  reports an explicit error when it cannot determine the state (never a silent "no Focus"),
+  and reports whether the running macOS version is known-supported.
+
+## User Story
+
+As an agent system operator, I want a narrow macOS helper that reports the current Focus state
+  over a local socket, so that my agent can react to Focus
+  without itself holding Full Disk Access or broad macOS automation permissions,
+  and without the agent's identity churn breaking that access.
+
+## Acceptance Criteria
+
+### Helper Identity and Lifecycle
+
+- [ ] The helper is distributed as a code-signed `.app` bundle installed at a stable path
+        with a stable bundle identifier and a stable signing identity.
+- [ ] The helper runs as a per-user LaunchAgent — not a system LaunchDaemon —
+        because Focus state is user-specific and the relevant files live under the user's home directory.
+- [ ] Any macOS privacy permission the helper needs (Full Disk Access, if macOS requires it
+        to read the Focus database) is granted to the helper, not to any client.
+- [ ] Clients that talk to the helper receive no Full Disk Access, Accessibility, Screen Recording,
+        or Automation permission as a result.
+
+### API Surface
+
+- [ ] The helper exposes exactly one operation over a local Unix domain socket: `get_focus()`,
+        returning a `FocusState`.
+- [ ] The helper does not expose `read_file(path)`, `run_shell(command)`, `run_shortcut(name)`,
+        `run_osascript(script)`, `query_db(path)`, or any other general-purpose or arbitrary operation.
+- [ ] The helper is read-only: it never modifies Focus, notifications, or any system setting.
+- [ ] The agent-facing interface (`get_focus() -> FocusState`) is stable and decoupled from the
+        underlying Focus-database schema; parser changes do not change the interface.
+
+### `FocusState` Data Model
+
+- [ ] `FocusState` has these fields with these meanings:
+      - `ok` (boolean): whether the helper successfully determined the Focus state.
+      - `focus_enabled` (boolean or null): whether a Focus is currently active;
+          `null` only when `ok` is `false`.
+      - `focus_name` (string or null): the human-readable Focus name;
+          `null` when Focus is off, or when the name could not be determined, or when `ok` is `false`.
+      - `macos_version` (string): the detected macOS version.
+      - `macos_compatibility` (enum): one of `supported`, `unknown_but_working`, `unknown`,
+          or `unsupported`.
+      - `message` (string or null): human-readable guidance; never load-bearing for program logic.
+      - `error` (string, present on failures): a stable machine-readable error code
+          (e.g. `focus_db_unreadable`, `schema_unknown`).
+- [ ] The helper does not include speculative fields (e.g. `normalized`, `source`)
+        without a concrete consumer need.
+- [ ] All four documented response shapes are produced correctly:
+        (a) success, Focus on, with a name;
+        (b) success, no Focus on;
+        (c) success on an unknown-but-working macOS version (with `macos_compatibility:
+        unknown_but_working` and a "please report this version" `message`);
+        (d) failure (`ok: false`, `focus_enabled: null`, `focus_name: null`, an `error` code,
+        and a "please file an issue/PR with your macOS version, helper version, and this error code"
+        `message`).
+
+### Consumer Logic
+
+- [ ] The response model lets a consumer decide the state with a simple, unambiguous rule:
+        if `ok` is `false`, the state is unknown;
+        else if `focus_enabled` is `false`, Focus is off;
+        else if `focus_enabled` is `true` and `focus_name` is non-null, Focus is on with that name;
+        else (`focus_enabled` is `true` and `focus_name` is null) Focus is on but the name could not
+        be determined.
+- [ ] A consumer can distinguish "no Focus is active", "a Focus is active but unnamed/unmapped",
+        "the helper failed", and "the macOS version is unsupported" from each other.
+
+### Retrieval Logic
+
+- [ ] Determining the Focus state follows this logic: detect the macOS version;
+        check it against the known-supported list;
+        read the active-assertions data and determine whether an active Focus assertion exists;
+        if none exists, return `ok: true`, `focus_enabled: false`, `focus_name: null`;
+        if one exists, extract the active Focus identifier, read the mode-configuration data,
+        and map the identifier to a human-readable Focus name.
+- [ ] If parsing succeeds on a macOS version that is not on the known-supported list,
+        the response sets `macos_compatibility: unknown_but_working` and includes the
+        "please report this version" guidance.
+
+### Failure Handling
+
+- [ ] The helper tolerates missing files, unreadable files, malformed JSON, schema changes,
+        and partially-written files without crashing.
+- [ ] Any failure to determine the Focus state is reported explicitly:
+        `ok: false`, `focus_enabled: null`, `focus_name: null`, and a stable `error` code.
+- [ ] A parsing or schema failure is never reported as `ok: true`, `focus_enabled: false`.
+
+### macOS Compatibility
+
+- [ ] The project maintains an explicit macOS-version compatibility table,
+        seeded with: macOS 14 Sonoma — supported; macOS 15 Sequoia — supported;
+        macOS 26 Tahoe — unknown until tested.
+- [ ] On an unknown-but-working macOS version, the response asks the user to submit an issue or PR
+        marking that version as compatible.
+- [ ] On a parsing failure, the response asks the user to file an issue or PR with their macOS version,
+        the helper version, and the error code.
+
+### Testing
+
+- [ ] At least one unit or integration test covers the retrieval logic against fixture
+        Focus-database files representing Focus-on, Focus-off, and malformed/unknown-schema cases,
+        for each known-supported macOS version.
+- [ ] An end-to-end test verifies that a client can connect to the running helper over the socket
+        and receive a well-formed `FocusState` (exercised against a real macOS session where feasible,
+        otherwise against fixture data with the real socket and process).
+
+## References
+
+### Vision
+
+- [macOS Focus Gopher](../product-vision/2026-05-12-macos-focus-gopher.md) —
+    The product context: letting unprivileged agents read macOS Focus state via a narrow,
+    stable-identity helper.
+
+### Engineering Design
+
+- [macOS Focus Gopher Engineering Design](../engineering-designs/2026-05-12-macos-focus-gopher.md) —
+    The technical approach: a Swift `.app` LaunchAgent, a Unix-domain-socket JSON protocol,
+    and a versioned read-only parser of the macOS Focus database.
+
+### Engineering Principles
+
+- [Least Privilege](../engineering-principles/2026-05-12-least-privilege.md) —
+    The helper exposes the narrowest capability that does the job, and brokers privileged access
+    so the broad permission never reaches the agent.
+- [Clear, Unambiguous, Easily-Parsed Data Models](../engineering-principles/2026-05-12-clear-data-models.md) —
+    `FocusState` separates orthogonal facts and never collapses "failed" into "no Focus".
+
+### Related Requirements
+
+- None.
+
+### Implementation
+
+- None yet.

--- a/design/product-requirements/2026-05-12-macos-focus-gopher.md
+++ b/design/product-requirements/2026-05-12-macos-focus-gopher.md
@@ -19,9 +19,10 @@ prs: []
 A per-user macOS helper that an unprivileged local client (e.g. an LLM/agent system) can query
   to learn the current macOS Focus state, without the client process itself holding Full Disk Access
   or any other broad macOS privacy permission.
-The helper is a code-signed `.app` with a stable identity, run as a per-user LaunchAgent,
-  exposing exactly one read-only operation over a local Unix domain socket:
-  `get_focus()`, returning a fixed-schema `FocusState`.
+The helper is a code-signed (and notarized) app with a stable identity, run as a per-user LaunchAgent,
+  exposing exactly one read-only operation, `get_focus()`, returning a fixed-schema `FocusState`,
+  over a local Unix domain socket — with a thin command-line wrapper for callers who prefer to run a
+  command.
 The helper performs the privileged, undocumented Focus-database read itself,
   reports an explicit error when it cannot determine the state (never a silent "no Focus"),
   and reports whether the running macOS version is known-supported.
@@ -29,7 +30,7 @@ The helper performs the privileged, undocumented Focus-database read itself,
 ## User Story
 
 As an agent system operator, I want a narrow macOS helper that reports the current Focus state
-  over a local socket, so that my agent can react to Focus
+  over a local socket (or a one-line command), so that my agent can react to Focus
   without itself holding Full Disk Access or broad macOS automation permissions,
   and without the agent's identity churn breaking that access.
 
@@ -37,7 +38,7 @@ As an agent system operator, I want a narrow macOS helper that reports the curre
 
 ### Helper Identity and Lifecycle
 
-- [ ] The helper is distributed as a code-signed `.app` bundle installed at a stable path
+- [ ] The helper is distributed as a code-signed and notarized app bundle installed at a stable path
         with a stable bundle identifier and a stable signing identity.
 - [ ] The helper runs as a per-user LaunchAgent — not a system LaunchDaemon —
         because Focus state is user-specific and the relevant files live under the user's home directory.
@@ -48,17 +49,22 @@ As an agent system operator, I want a narrow macOS helper that reports the curre
 
 ### API Surface
 
-- [ ] The helper exposes exactly one operation over a local Unix domain socket: `get_focus()`,
-        returning a `FocusState`.
+- [ ] The helper exposes exactly one operation, `get_focus()`, returning a `FocusState`.
+        Its primary transport is a local Unix domain socket; a thin command-line wrapper is also
+        provided that performs the same `get_focus()` call over that socket and prints the `FocusState`
+        as JSON. Both transports expose the same single operation and nothing more.
 - [ ] The helper does not expose `read_file(path)`, `run_shell(command)`, `run_shortcut(name)`,
         `run_osascript(script)`, `query_db(path)`, or any other general-purpose or arbitrary operation.
 - [ ] The helper is read-only: it never modifies Focus, notifications, or any system setting.
 - [ ] The agent-facing interface (`get_focus() -> FocusState`) is stable and decoupled from the
         underlying Focus-database schema; parser changes do not change the interface.
+- [ ] A versioned JSON Schema for `FocusState` is published and referenced from all of the project's
+        documentation; the helper's output validates against it.
 
 ### `FocusState` Data Model
 
-- [ ] `FocusState` has these fields with these meanings:
+- [ ] `FocusState` is a single, flat object (a small single-purpose response; deliberately not nested),
+        with these fields and meanings:
       - `ok` (boolean): whether the helper successfully determined the Focus state.
       - `focus_enabled` (boolean or null): whether a Focus is currently active;
           `null` only when `ok` is `false`.
@@ -70,8 +76,8 @@ As an agent system operator, I want a narrow macOS helper that reports the curre
       - `message` (string or null): human-readable guidance; never load-bearing for program logic.
       - `error` (string, present on failures): a stable machine-readable error code
           (e.g. `focus_db_unreadable`, `schema_unknown`).
-- [ ] The helper does not include speculative fields (e.g. `normalized`, `source`)
-        without a concrete consumer need.
+- [ ] The helper does not include speculative fields (e.g. `normalized`, `source`, or a list of all
+        known-compatible macOS versions) without a concrete consumer need.
 - [ ] All four documented response shapes are produced correctly:
         (a) success, Focus on, with a name;
         (b) success, no Focus on;
@@ -97,9 +103,13 @@ As an agent system operator, I want a narrow macOS helper that reports the curre
 - [ ] Determining the Focus state follows this logic: detect the macOS version;
         check it against the known-supported list;
         read the active-assertions data and determine whether an active Focus assertion exists;
-        if none exists, return `ok: true`, `focus_enabled: false`, `focus_name: null`;
+        if none exists, return `ok: true`, `focus_enabled: false`, `focus_name: null`
+        (an empty active-assertions file is a valid "Focus is off" result, not an error);
         if one exists, extract the active Focus identifier, read the mode-configuration data,
         and map the identifier to a human-readable Focus name.
+- [ ] The helper accounts for the documented quirks of the Focus database (see the analysis referenced
+        below): a Focus activated by schedule or automation is reflected differently than a manually
+        toggled one, so both the active-assertions data and the mode-configuration data are consulted.
 - [ ] If parsing succeeds on a macOS version that is not on the known-supported list,
         the response sets `macos_compatibility: unknown_but_working` and includes the
         "please report this version" guidance.
@@ -114,22 +124,47 @@ As an agent system operator, I want a narrow macOS helper that reports the curre
 
 ### macOS Compatibility
 
-- [ ] The project maintains an explicit macOS-version compatibility table,
-        seeded with: macOS 14 Sonoma — supported; macOS 15 Sequoia — supported;
-        macOS 26 Tahoe — unknown until tested.
+- [ ] The project maintains an explicit macOS-version compatibility table, keyed by macOS version
+        string. An entry may be a specific point release (e.g. `15.5`) or a major-version wildcard
+        (e.g. `15.*`). A major-version wildcard is permitted only when the format-stability analysis
+        (referenced below) supports it for that major *and* the parser has been verified against at
+        least one current point release of that major.
+- [ ] The table is seeded per that analysis: macOS 12–15 are reasonable `supported` (wildcard) entries
+        once verified; macOS 11 and earlier are out of scope (a different mechanism); the current macOS
+        26 starts as `unknown` until verified.
 - [ ] On an unknown-but-working macOS version, the response asks the user to submit an issue or PR
         marking that version as compatible.
 - [ ] On a parsing failure, the response asks the user to file an issue or PR with their macOS version,
         the helper version, and the error code.
 
+### Distribution and Documentation
+
+- [ ] The helper can be installed with a single command via Homebrew (a formula or tap), which handles
+        the app bundle, the LaunchAgent registration, and putting the CLI wrapper on the user's `PATH`.
+- [ ] The project `README.md` clearly and concisely explains who the Focus Gopher is for, what problem
+        it solves, and how to start using it — written to engage both human and agent readers, with at
+        least one short, deliberately slow/clear screen-recording GIF demonstrating it, and including or
+        referencing (depending on length) the full `--help`/`man` documentation.
+- [ ] The `--help` output and/or `man` page are themselves clear, concise, useful to both human and
+        agent readers, and include worked examples for every common operation and its result.
+- [ ] The project ships bundled agent skills plus a simple command that installs them into the user's
+        home directory or a specified project for common agent harnesses (e.g. Claude Code, Codex).
+- [ ] The project has a clear OSS license (MIT, unless a better-established commercially-friendly choice
+        is preferred at the time).
+- [ ] The project has a `CONTRIBUTING.md` that orients contributors by briefly introducing the
+        architecture and development workflow (largely by linking to these design docs) and by pointing
+        at the repository-root `CONTRIBUTING.md`, without duplicating its content.
+
 ### Testing
 
 - [ ] At least one unit or integration test covers the retrieval logic against fixture
-        Focus-database files representing Focus-on, Focus-off, and malformed/unknown-schema cases,
-        for each known-supported macOS version.
+        Focus-database files representing Focus-on (manual and scheduled), Focus-off (including the
+        empty-file case), and malformed/unknown-schema cases, for each supported macOS major version
+        (verified against at least one current point release of each).
 - [ ] An end-to-end test verifies that a client can connect to the running helper over the socket
-        and receive a well-formed `FocusState` (exercised against a real macOS session where feasible,
-        otherwise against fixture data with the real socket and process).
+        (and that the CLI wrapper works) and receive a well-formed `FocusState` (exercised against a
+        real macOS session where feasible, otherwise against fixture data with the real socket and
+        process).
 
 ## References
 
@@ -142,8 +177,15 @@ As an agent system operator, I want a narrow macOS helper that reports the curre
 ### Engineering Design
 
 - [macOS Focus Gopher Engineering Design](../engineering-designs/2026-05-12-macos-focus-gopher.md) —
-    The technical approach: a Swift `.app` LaunchAgent, a Unix-domain-socket JSON protocol,
-    and a versioned read-only parser of the macOS Focus database.
+    The technical approach: a Rust helper packaged as a code-signed `.app` LaunchAgent, a
+    Unix-domain-socket JSON protocol with a thin CLI wrapper, and a versioned read-only parser of the
+    macOS Focus database.
+
+### Analysis
+
+- [macOS Focus Database Format and Stability](../analyses/2026-05-12-macos-focus-db-format.md) —
+    Where the Focus state lives, how the format has held up across macOS 12–15, and the basis for the
+    compatibility-table seeding (specific versions vs. major-version wildcards).
 
 ### Engineering Principles
 

--- a/design/product-requirements/2026-05-12-macos-focus-gopher.md
+++ b/design/product-requirements/2026-05-12-macos-focus-gopher.md
@@ -80,10 +80,9 @@ As an agent system operator, I want a narrow macOS helper that reports the curre
         JSON-shape analysis referenced below); Rust's `Result`/`Option` plumbing is hidden behind
         domain-named keys, never serialized as `Ok`/`Err`/`null`. It has these shared fields and meanings:
       - `macos_version` (string): the detected macOS version.
-      - `macos_compatibility` (enum): one of `supported`, `unknown_but_working`, `unknown`,
-          or `unsupported`.
-      - `message` (string, optional): human-readable guidance; omitted when there is none, and never
-          load-bearing for program logic.
+      - `macos_compatibility` (tagged enum): `supported`, `unsupported`, or `unknown` (on neither
+          list). The `unknown` variant carries a `message` asking the user to report whether parsing
+          worked; whether it actually worked is conveyed by the outcome, not this field.
 - [ ] Alongside the shared fields, the response carries **exactly one outcome**:
       - `determined`: the helper determined the state. Its value is itself a tagged union of exactly one
           of:
@@ -91,7 +90,7 @@ As an agent system operator, I want a narrow macOS helper that reports the curre
         - `focus_off`: no Focus is active (an empty object).
       - `failed`: the helper could not determine the state; carries a stable machine-readable `error`
           code (e.g. `focus_permission_denied`, `focus_db_unreadable`, `schema_unknown`,
-          `focus_name_unresolved`).
+          `focus_name_unresolved`) plus a human-readable `message` with guidance for that error.
 - [ ] An active Focus whose identifier cannot be mapped to a name is reported as `failed` with
         `focus_name_unresolved`, not as a success — the name is the primary thing consumers want, and in
         normal operation an active Focus is always nameable, so a nameless "Focus is on" indicates a
@@ -101,10 +100,11 @@ As an agent system operator, I want a narrow macOS helper that reports the curre
 - [ ] All four documented response shapes are produced correctly:
         (a) `determined` → `focus_on` with a name;
         (b) `determined` → `focus_off`;
-        (c) `determined` on an unknown-but-working macOS version (with `macos_compatibility:
-        unknown_but_working` and a "please report this version" `message`);
-        (d) `failed` (with an `error` code and a "please file an issue/PR with your macOS version,
-        helper version, and this error code" `message`).
+        (c) `determined` on an `unknown` (unlisted) macOS version, where `macos_compatibility` is the
+        `unknown` variant carrying a "please report whether this version works" `message`;
+        (d) `failed` (with an `error` code and a guidance `message` — e.g. the FDA-grant steps for
+        `focus_permission_denied`, or a "file an issue/PR with your macOS version, helper version, and
+        this error code" nudge otherwise).
 
 ### Consumer Logic
 
@@ -131,9 +131,9 @@ As an agent system operator, I want a narrow macOS helper that reports the curre
 - [ ] The helper accounts for the documented quirks of the Focus database (see the analysis referenced
         below): a Focus activated by schedule or automation is reflected differently than a manually
         toggled one, so both the active-assertions data and the mode-configuration data are consulted.
-- [ ] If parsing succeeds on a macOS version that is not on the known-supported list,
-        the response sets `macos_compatibility: unknown_but_working` and includes the
-        "please report this version" guidance.
+- [ ] If the running macOS version is on neither the supported nor the unsupported list, the response
+        sets `macos_compatibility` to the `unknown` variant, carrying a "please report whether this
+        version works" `message` (whether parsing actually worked is conveyed by the outcome).
 
 ### Failure Handling
 
@@ -157,8 +157,8 @@ As an agent system operator, I want a narrow macOS helper that reports the curre
 - [ ] The table is seeded per that analysis: macOS 12–15 are reasonable `supported` (wildcard) entries
         once verified; macOS 11 and earlier are out of scope (a different mechanism); the current macOS
         26 starts as `unknown` until verified.
-- [ ] On an unknown-but-working macOS version, the response asks the user to submit an issue or PR
-        marking that version as compatible.
+- [ ] On an `unknown` (unlisted) macOS version, the `macos_compatibility` `unknown` variant's `message`
+        asks the user to submit an issue or PR reporting whether this version works.
 - [ ] On a parsing failure, the response asks the user to file an issue or PR with their macOS version,
         the helper version, and the error code.
 

--- a/design/product-requirements/2026-05-12-macos-focus-gopher.md
+++ b/design/product-requirements/2026-05-12-macos-focus-gopher.md
@@ -53,6 +53,9 @@ As an agent system operator, I want a narrow macOS helper that reports the curre
         Its primary transport is a local Unix domain socket; a thin command-line wrapper is also
         provided that performs the same `get_focus()` call over that socket and prints the `FocusState`
         as JSON. Both transports expose the same single operation and nothing more.
+- [ ] The command-line wrapper exits with a non-zero status when `ok` is `false` (and zero otherwise),
+        so shell scripts can branch on the exit code without parsing the JSON; the JSON body still
+        carries `ok` and `error` for programmatic consumers reading the socket directly.
 - [ ] The helper does not expose `read_file(path)`, `run_shell(command)`, `run_shortcut(name)`,
         `run_osascript(script)`, `query_db(path)`, or any other general-purpose or arbitrary operation.
 - [ ] The helper is read-only: it never modifies Focus, notifications, or any system setting.
@@ -63,8 +66,8 @@ As an agent system operator, I want a narrow macOS helper that reports the curre
 
 ### `FocusState` Data Model
 
-- [ ] `FocusState` is a single, flat object (a small single-purpose response; deliberately not nested),
-        with these fields and meanings:
+- [ ] `FocusState` is a single, flat object — a small single-purpose response, flat rather than nested
+        (see the JSON-shape analysis referenced below) — with these fields and meanings:
       - `ok` (boolean): whether the helper successfully determined the Focus state.
       - `focus_enabled` (boolean or null): whether a Focus is currently active;
           `null` only when `ok` is `false`.
@@ -186,6 +189,9 @@ As an agent system operator, I want a narrow macOS helper that reports the curre
 - [macOS Focus Database Format and Stability](../analyses/2026-05-12-macos-focus-db-format.md) —
     Where the Focus state lives, how the format has held up across macOS 12–15, and the basis for the
     compatibility-table seeding (specific versions vs. major-version wildcards).
+- [`FocusState` JSON Response Shape: Flat vs. Nested](../analyses/2026-05-12-focus-state-json-shape.md) —
+    Why `FocusState` is a flat object rather than a nested envelope, and why the CLI wrapper carries the
+    success/failure signal in its exit code as well as in `ok`.
 
 ### Engineering Principles
 

--- a/design/product-requirements/2026-05-12-macos-focus-gopher.md
+++ b/design/product-requirements/2026-05-12-macos-focus-gopher.md
@@ -19,10 +19,13 @@ prs: []
 A per-user macOS helper that an unprivileged local client (e.g. an LLM/agent system) can query
   to learn the current macOS Focus state, without the client process itself holding Full Disk Access
   or any other broad macOS privacy permission.
-The helper is a code-signed (and notarized) app with a stable identity, run as a per-user LaunchAgent,
-  exposing exactly one read-only operation, `get_focus()`, returning a fixed-schema `FocusState`,
-  over a local Unix domain socket — with a thin command-line wrapper for callers who prefer to run a
-  command.
+The helper is a stable-identity app bundle (a fixed install path and bundle identifier), run as a
+  per-user LaunchAgent, exposing exactly one read-only operation, `get_focus()`, returning a
+  fixed-schema `FocusState`, over a local Unix domain socket — with a thin command-line wrapper for
+  callers who prefer to run a command.
+Developer ID code signing and notarization are an optional later enhancement — they make the Full Disk
+  Access grant persist across upgrades and improve first-run signposting, but are not required for the
+  helper to be fully functional.
 The helper performs the privileged, undocumented Focus-database read itself,
   reports an explicit error when it cannot determine the state (never a silent "no Focus"),
   and reports whether the running macOS version is known-supported.
@@ -38,12 +41,17 @@ As an agent system operator, I want a narrow macOS helper that reports the curre
 
 ### Helper Identity and Lifecycle
 
-- [ ] The helper is distributed as a code-signed and notarized app bundle installed at a stable path
-        with a stable bundle identifier and a stable signing identity.
+- [ ] The helper is distributed as an app bundle installed at a stable path with a stable bundle
+        identifier (the unit the macOS privacy grant attaches to).
+- [ ] Developer ID code signing and Apple notarization are an *optional* later enhancement, not
+        required for the helper to be fully functional; when present they make the Full Disk Access
+        grant persist across helper upgrades (otherwise the user re-applies it after each upgrade on
+        the build-from-source channels). See the analysis referenced below.
 - [ ] The helper runs as a per-user LaunchAgent — not a system LaunchDaemon —
         because Focus state is user-specific and the relevant files live under the user's home directory.
-- [ ] Any macOS privacy permission the helper needs (Full Disk Access, if macOS requires it
-        to read the Focus database) is granted to the helper, not to any client.
+- [ ] Any macOS privacy permission the helper needs (Full Disk Access, which macOS requires to read the
+        Focus database) is granted to the helper, not to any client; this grant is always a manual
+        System Settings action, as macOS exposes no programmatic prompt for it.
 - [ ] Clients that talk to the helper receive no Full Disk Access, Accessibility, Screen Recording,
         or Automation permission as a result.
 
@@ -78,7 +86,7 @@ As an agent system operator, I want a narrow macOS helper that reports the curre
           or `unsupported`.
       - `message` (string or null): human-readable guidance; never load-bearing for program logic.
       - `error` (string, present on failures): a stable machine-readable error code
-          (e.g. `focus_db_unreadable`, `schema_unknown`).
+          (e.g. `focus_permission_denied`, `focus_db_unreadable`, `schema_unknown`).
 - [ ] The helper does not include speculative fields (e.g. `normalized`, `source`, or a list of all
         known-compatible macOS versions) without a concrete consumer need.
 - [ ] All four documented response shapes are produced correctly:
@@ -119,11 +127,15 @@ As an agent system operator, I want a narrow macOS helper that reports the curre
 
 ### Failure Handling
 
-- [ ] The helper tolerates missing files, unreadable files, malformed JSON, schema changes,
-        and partially-written files without crashing.
+- [ ] The helper tolerates missing files, permission-denied files, unreadable files, malformed JSON,
+        schema changes, and partially-written files without crashing.
 - [ ] Any failure to determine the Focus state is reported explicitly:
         `ok: false`, `focus_enabled: null`, `focus_name: null`, and a stable `error` code.
 - [ ] A parsing or schema failure is never reported as `ok: true`, `focus_enabled: false`.
+- [ ] A missing Full Disk Access grant is detected (a permission denial on the existing Focus
+        database) and reported as a dedicated `focus_permission_denied` error code — never as
+        `ok: true, focus_enabled: false` — with an actionable `message`: the canonical resolved helper
+        binary path to add and a System Settings deep link to the Full Disk Access pane.
 
 ### macOS Compatibility
 
@@ -142,8 +154,13 @@ As an agent system operator, I want a narrow macOS helper that reports the curre
 
 ### Distribution and Documentation
 
-- [ ] The helper can be installed with a single command via Homebrew (a formula or tap), which handles
-        the app bundle, the LaunchAgent registration, and putting the CLI wrapper on the user's `PATH`.
+- [ ] The helper can be installed with a single command via build-from-source channels — Homebrew
+        (a formula in a tap) or `cargo install` — which handle the app bundle, the LaunchAgent
+        registration, and putting the CLI wrapper on the user's `PATH`. A signed + notarized Homebrew
+        cask is an optional later addition, not required here.
+- [ ] The documentation explains, prominently, exactly how to grant Full Disk Access to the helper
+        (the precise System Settings steps and the resolved binary path), and that on the
+        build-from-source channels the grant must be re-applied after each upgrade.
 - [ ] The project `README.md` clearly and concisely explains who the Focus Gopher is for, what problem
         it solves, and how to start using it — written to engage both human and agent readers, with at
         least one short, deliberately slow/clear screen-recording GIF demonstrating it, and including or
@@ -180,9 +197,9 @@ As an agent system operator, I want a narrow macOS helper that reports the curre
 ### Engineering Design
 
 - [macOS Focus Gopher Engineering Design](../engineering-designs/2026-05-12-macos-focus-gopher.md) —
-    The technical approach: a Rust helper packaged as a code-signed `.app` LaunchAgent, a
-    Unix-domain-socket JSON protocol with a thin CLI wrapper, and a versioned read-only parser of the
-    macOS Focus database.
+    The technical approach: a Rust helper packaged as a stable-identity `.app` LaunchAgent
+    (Developer ID signing/notarization an optional later enhancement), a Unix-domain-socket JSON
+    protocol with a thin CLI wrapper, and a versioned read-only parser of the macOS Focus database.
 
 ### Analysis
 
@@ -192,6 +209,10 @@ As an agent system operator, I want a narrow macOS helper that reports the curre
 - [`FocusState` JSON Response Shape: Flat vs. Nested](../analyses/2026-05-12-focus-state-json-shape.md) —
     Why `FocusState` is a flat object rather than a nested envelope, and why the CLI wrapper carries the
     success/failure signal in its exit code as well as in `ok`.
+- [macOS Full Disk Access, Code Signing, and Distribution Channels](../analyses/2026-05-18-macos-fda-distribution-signing.md) —
+    Why signing/notarization are deferred optional UX improvements, how each distribution channel
+    interacts with the Full Disk Access grant, and why graceful missing-FDA handling is a first-class
+    early requirement.
 
 ### Engineering Principles
 

--- a/design/product-requirements/2026-05-12-macos-focus-gopher.md
+++ b/design/product-requirements/2026-05-12-macos-focus-gopher.md
@@ -61,9 +61,10 @@ As an agent system operator, I want a narrow macOS helper that reports the curre
         Its primary transport is a local Unix domain socket; a thin command-line wrapper is also
         provided that performs the same `get_focus()` call over that socket and prints the `FocusState`
         as JSON. Both transports expose the same single operation and nothing more.
-- [ ] The command-line wrapper exits with a non-zero status when `ok` is `false` (and zero otherwise),
-        so shell scripts can branch on the exit code without parsing the JSON; the JSON body still
-        carries `ok` and `error` for programmatic consumers reading the socket directly.
+- [ ] The command-line wrapper exits with a non-zero status when the outcome is `failed` (and zero
+        otherwise), so shell scripts can branch on the exit code without parsing the JSON; the JSON body
+        still carries the `determined`/`failed` outcome (and, on failure, the `error` code) for
+        programmatic consumers reading the socket directly.
 - [ ] The helper does not expose `read_file(path)`, `run_shell(command)`, `run_shortcut(name)`,
         `run_osascript(script)`, `query_db(path)`, or any other general-purpose or arbitrary operation.
 - [ ] The helper is read-only: it never modifies Focus, notifications, or any system setting.
@@ -74,50 +75,59 @@ As an agent system operator, I want a narrow macOS helper that reports the curre
 
 ### `FocusState` Data Model
 
-- [ ] `FocusState` is a single, flat object — a small single-purpose response, flat rather than nested
-        (see the JSON-shape analysis referenced below) — with these fields and meanings:
-      - `ok` (boolean): whether the helper successfully determined the Focus state.
-      - `focus_enabled` (boolean or null): whether a Focus is currently active;
-          `null` only when `ok` is `false`.
-      - `focus_name` (string or null): the human-readable Focus name;
-          `null` when Focus is off, or when the name could not be determined, or when `ok` is `false`.
+- [ ] `FocusState` is an **externally-tagged discriminated union** whose wire shape mirrors the helper's
+        internal strongly-typed model rather than flattening it into nullable siblings (see the
+        JSON-shape analysis referenced below); Rust's `Result`/`Option` plumbing is hidden behind
+        domain-named keys, never serialized as `Ok`/`Err`/`null`. It has these shared fields and meanings:
       - `macos_version` (string): the detected macOS version.
       - `macos_compatibility` (enum): one of `supported`, `unknown_but_working`, `unknown`,
           or `unsupported`.
-      - `message` (string or null): human-readable guidance; never load-bearing for program logic.
-      - `error` (string, present on failures): a stable machine-readable error code
-          (e.g. `focus_permission_denied`, `focus_db_unreadable`, `schema_unknown`).
+      - `message` (string, optional): human-readable guidance; omitted when there is none, and never
+          load-bearing for program logic.
+- [ ] Alongside the shared fields, the response carries **exactly one outcome**:
+      - `determined`: the helper determined the state. Its value is itself a tagged union of exactly one
+          of:
+        - `focus_on`: a Focus is active; carries its human-readable `name` (always present).
+        - `focus_off`: no Focus is active (an empty object).
+      - `failed`: the helper could not determine the state; carries a stable machine-readable `error`
+          code (e.g. `focus_permission_denied`, `focus_db_unreadable`, `schema_unknown`,
+          `focus_name_unresolved`).
+- [ ] An active Focus whose identifier cannot be mapped to a name is reported as `failed` with
+        `focus_name_unresolved`, not as a success — the name is the primary thing consumers want, and in
+        normal operation an active Focus is always nameable, so a nameless "Focus is on" indicates a
+        schema/coverage gap worth reporting rather than a steady-state partial success.
 - [ ] The helper does not include speculative fields (e.g. `normalized`, `source`, or a list of all
         known-compatible macOS versions) without a concrete consumer need.
 - [ ] All four documented response shapes are produced correctly:
-        (a) success, Focus on, with a name;
-        (b) success, no Focus on;
-        (c) success on an unknown-but-working macOS version (with `macos_compatibility:
+        (a) `determined` → `focus_on` with a name;
+        (b) `determined` → `focus_off`;
+        (c) `determined` on an unknown-but-working macOS version (with `macos_compatibility:
         unknown_but_working` and a "please report this version" `message`);
-        (d) failure (`ok: false`, `focus_enabled: null`, `focus_name: null`, an `error` code,
-        and a "please file an issue/PR with your macOS version, helper version, and this error code"
-        `message`).
+        (d) `failed` (with an `error` code and a "please file an issue/PR with your macOS version,
+        helper version, and this error code" `message`).
 
 ### Consumer Logic
 
-- [ ] The response model lets a consumer decide the state with a simple, unambiguous rule:
-        if `ok` is `false`, the state is unknown;
-        else if `focus_enabled` is `false`, Focus is off;
-        else if `focus_enabled` is `true` and `focus_name` is non-null, Focus is on with that name;
-        else (`focus_enabled` is `true` and `focus_name` is null) Focus is on but the name could not
-        be determined.
-- [ ] A consumer can distinguish "no Focus is active", "a Focus is active but unnamed/unmapped",
-        "the helper failed", and "the macOS version is unsupported" from each other.
+- [ ] The response model lets a consumer decide the state with a simple, unambiguous rule
+        (exactly one of `determined`/`failed` is present):
+        if `failed` is present, the state is unknown (consult its `error`);
+        else `determined` is present and holds exactly one of `focus_off` (no Focus active) or
+        `focus_on` (a Focus is active, carrying its `name`).
+- [ ] A consumer can distinguish "no Focus is active", "an active Focus with its name",
+        "the helper failed" (including an active-but-unnameable Focus, via `focus_name_unresolved`),
+        and "the macOS version is unsupported" from each other.
 
 ### Retrieval Logic
 
 - [ ] Determining the Focus state follows this logic: detect the macOS version;
         check it against the known-supported list;
         read the active-assertions data and determine whether an active Focus assertion exists;
-        if none exists, return `ok: true`, `focus_enabled: false`, `focus_name: null`
+        if none exists, return `determined` → `focus_off`
         (an empty active-assertions file is a valid "Focus is off" result, not an error);
         if one exists, extract the active Focus identifier, read the mode-configuration data,
-        and map the identifier to a human-readable Focus name.
+        and map the identifier to a human-readable Focus name (returned as `determined` → `focus_on`
+        with that `name`; if the identifier cannot be mapped, return `failed` with
+        `focus_name_unresolved`).
 - [ ] The helper accounts for the documented quirks of the Focus database (see the analysis referenced
         below): a Focus activated by schedule or automation is reflected differently than a manually
         toggled one, so both the active-assertions data and the mode-configuration data are consulted.
@@ -129,13 +139,13 @@ As an agent system operator, I want a narrow macOS helper that reports the curre
 
 - [ ] The helper tolerates missing files, permission-denied files, unreadable files, malformed JSON,
         schema changes, and partially-written files without crashing.
-- [ ] Any failure to determine the Focus state is reported explicitly:
-        `ok: false`, `focus_enabled: null`, `focus_name: null`, and a stable `error` code.
-- [ ] A parsing or schema failure is never reported as `ok: true`, `focus_enabled: false`.
+- [ ] Any failure to determine the Focus state is reported explicitly as `failed` with a stable `error`
+        code (never as a `determined` result).
+- [ ] A parsing or schema failure is never reported as `determined` → `focus_off`.
 - [ ] A missing Full Disk Access grant is detected (a permission denial on the existing Focus
-        database) and reported as a dedicated `focus_permission_denied` error code — never as
-        `ok: true, focus_enabled: false` — with an actionable `message`: the canonical resolved helper
-        binary path to add and a System Settings deep link to the Full Disk Access pane.
+        database) and reported as `failed` with a dedicated `focus_permission_denied` error code — never
+        as a `determined` result — with an actionable `message`: the canonical resolved helper binary
+        path to add and a System Settings deep link to the Full Disk Access pane.
 
 ### macOS Compatibility
 
@@ -206,9 +216,10 @@ As an agent system operator, I want a narrow macOS helper that reports the curre
 - [macOS Focus Database Format and Stability](../analyses/2026-05-12-macos-focus-db-format.md) —
     Where the Focus state lives, how the format has held up across macOS 12–15, and the basis for the
     compatibility-table seeding (specific versions vs. major-version wildcards).
-- [`FocusState` JSON Response Shape: Flat vs. Nested](../analyses/2026-05-12-focus-state-json-shape.md) —
-    Why `FocusState` is a flat object rather than a nested envelope, and why the CLI wrapper carries the
-    success/failure signal in its exit code as well as in `ok`.
+- [`FocusState` JSON Response Shape: Flat vs. Tagged Union](../analyses/2026-05-12-focus-state-json-shape.md) —
+    Why `FocusState` is an externally-tagged discriminated union mirroring the helper's internal sum
+    type (no transport status code, so the body carries the discriminant), and why the CLI wrapper also
+    carries the success/failure signal in its exit code.
 - [macOS Full Disk Access, Code Signing, and Distribution Channels](../analyses/2026-05-18-macos-fda-distribution-signing.md) —
     Why signing/notarization are deferred optional UX improvements, how each distribution channel
     interacts with the Full Disk Access grant, and why graceful missing-FDA handling is a first-class

--- a/design/product-requirements/2026-05-12-macos-focus-gopher.md
+++ b/design/product-requirements/2026-05-12-macos-focus-gopher.md
@@ -16,19 +16,16 @@ prs: []
 
 ## Summary
 
-A per-user macOS helper that an unprivileged local client (e.g. an LLM/agent system) can query
-  to learn the current macOS Focus state, without the client process itself holding Full Disk Access
-  or any other broad macOS privacy permission.
-The helper is a stable-identity app bundle (a fixed install path and bundle identifier), run as a
-  per-user LaunchAgent, exposing exactly one read-only operation, `get_focus()`, returning a
-  fixed-schema `FocusState`, over a local Unix domain socket — with a thin command-line wrapper for
-  callers who prefer to run a command.
-Developer ID code signing and notarization are an optional later enhancement — they make the Full Disk
-  Access grant persist across upgrades and improve first-run signposting, but are not required for the
-  helper to be fully functional.
-The helper performs the privileged, undocumented Focus-database read itself,
-  reports an explicit error when it cannot determine the state (never a silent "no Focus"),
-  and reports whether the running macOS version is known-supported.
+A small macOS helper that an unprivileged local client (e.g. an LLM/agent system) can query to learn
+  the current macOS Focus state, without the client process itself holding Full Disk Access or any
+  other broad macOS privacy permission.
+It answers exactly one question — "what is the current Focus state?" — callable over a local socket or
+  via a one-line command, and it has a stable identity so the macOS permission it needs is tied to the
+  helper rather than to the client's churning identity.
+The helper performs the privileged read itself and answers from a fixed, documented schema: a Focus is
+  on (with its name), no Focus is on, or the state could not be determined — the last reported as an
+  explicit error with guidance, never a silent "no Focus" — along with whether the running macOS version
+  is known to be supported.
 
 ## User Story
 
@@ -39,144 +36,68 @@ As an agent system operator, I want a narrow macOS helper that reports the curre
 
 ## Acceptance Criteria
 
-### Helper Identity and Lifecycle
+### Privacy and Trust
 
-- [ ] The helper is distributed as an app bundle installed at a stable path with a stable bundle
-        identifier (the unit the macOS privacy grant attaches to).
-- [ ] Developer ID code signing and Apple notarization are an *optional* later enhancement, not
-        required for the helper to be fully functional; when present they make the Full Disk Access
-        grant persist across helper upgrades (otherwise the user re-applies it after each upgrade on
-        the build-from-source channels). See the analysis referenced below.
-- [ ] The helper runs as a per-user LaunchAgent — not a system LaunchDaemon —
-        because Focus state is user-specific and the relevant files live under the user's home directory.
-- [ ] Any macOS privacy permission the helper needs (Full Disk Access, which macOS requires to read the
-        Focus database) is granted to the helper, not to any client; this grant is always a manual
-        System Settings action, as macOS exposes no programmatic prompt for it.
-- [ ] Clients that talk to the helper receive no Full Disk Access, Accessibility, Screen Recording,
-        or Automation permission as a result.
+- [ ] A client can learn the current Focus state without itself holding Full Disk Access or any other
+        broad macOS privacy permission.
+- [ ] Talking to the helper grants a client no Full Disk Access, Accessibility, Screen Recording, or
+        Automation permission.
+- [ ] Whatever macOS permission the helper needs (Full Disk Access) is held by the helper, not by any
+        client. Granting it is a one-time manual step in System Settings (macOS offers no programmatic
+        prompt); on build-from-source installs the user re-applies it after an upgrade, and an optional
+        signed distribution (later) removes that re-grant.
+- [ ] The helper's access is not broken by the client being rebuilt, reinstalled, or launched
+        differently — the permission is tied to the helper's stable identity, not the client's.
 
-### API Surface
+### Capability and Surface
 
-- [ ] The helper exposes exactly one operation, `get_focus()`, returning a `FocusState`.
-        Its primary transport is a local Unix domain socket; a thin command-line wrapper is also
-        provided that performs the same `get_focus()` call over that socket and prints the `FocusState`
-        as JSON. Both transports expose the same single operation and nothing more.
-- [ ] The command-line wrapper exits with a non-zero status when the outcome is `failed` (and zero
-        otherwise), so shell scripts can branch on the exit code without parsing the JSON; the JSON body
-        still carries the `determined`/`failed` outcome (and, on failure, the `error` code) for
-        programmatic consumers reading the socket directly.
-- [ ] The helper does not expose `read_file(path)`, `run_shell(command)`, `run_shortcut(name)`,
-        `run_osascript(script)`, `query_db(path)`, or any other general-purpose or arbitrary operation.
-- [ ] The helper is read-only: it never modifies Focus, notifications, or any system setting.
-- [ ] The agent-facing interface (`get_focus() -> FocusState`) is stable and decoupled from the
-        underlying Focus-database schema; parser changes do not change the interface.
-- [ ] A versioned JSON Schema for `FocusState` is published and referenced from all of the project's
-        documentation; the helper's output validates against it.
+- [ ] The helper answers exactly one question — the current Focus state — callable over a local socket
+        or via a one-line command; both expose the same single operation and nothing more.
+- [ ] The helper is read-only: it never changes Focus, notifications, or any system setting.
+- [ ] The helper offers no general-purpose or arbitrary capability — no reading arbitrary files,
+        running shell commands, running Shortcuts, or running AppleScript — so a client that can reach
+        it gains only the ability to read Focus state.
 
-### `FocusState` Data Model
+### Response and Behavior
 
-- [ ] `FocusState` is an **externally-tagged discriminated union** whose wire shape mirrors the helper's
-        internal strongly-typed model rather than flattening it into nullable siblings (see the
-        JSON-shape analysis referenced below); Rust's `Result`/`Option` plumbing is hidden behind
-        domain-named keys, never serialized as `Ok`/`Err`/`null`. It has these shared fields and meanings:
-      - `macos_version` (string): the detected macOS version.
-      - `macos_compatibility` (tagged enum): `supported`, `unsupported`, or `unknown` (on neither
-          list). The `unknown` variant carries a `message` asking the user to report whether parsing
-          worked; whether it actually worked is conveyed by the outcome, not this field.
-- [ ] Alongside the shared fields, the response carries **exactly one outcome**:
-      - `determined`: the helper determined the state. Its value is itself a tagged union of exactly one
-          of:
-        - `focus_on`: a Focus is active; carries its human-readable `name` (always present).
-        - `focus_off`: no Focus is active (an empty object).
-      - `failed`: the helper could not determine the state; carries a stable machine-readable `error`
-          code (e.g. `focus_permission_denied`, `focus_db_unreadable`, `schema_unknown`,
-          `focus_name_unresolved`) plus a human-readable `message` with guidance for that error.
-- [ ] An active Focus whose identifier cannot be mapped to a name is reported as `failed` with
-        `focus_name_unresolved`, not as a success — the name is the primary thing consumers want, and in
-        normal operation an active Focus is always nameable, so a nameless "Focus is on" indicates a
-        schema/coverage gap worth reporting rather than a steady-state partial success.
-- [ ] The helper does not include speculative fields (e.g. `normalized`, `source`, or a list of all
-        known-compatible macOS versions) without a concrete consumer need.
-- [ ] All four documented response shapes are produced correctly:
-        (a) `determined` → `focus_on` with a name;
-        (b) `determined` → `focus_off`;
-        (c) `determined` on an `unknown` (unlisted) macOS version, where `macos_compatibility` is the
-        `unknown` variant carrying a "please report whether this version works" `message`;
-        (d) `failed` (with an `error` code and a guidance `message` — e.g. the FDA-grant steps for
-        `focus_permission_denied`, or a "file an issue/PR with your macOS version, helper version, and
-        this error code" nudge otherwise).
+- [ ] A consumer can unambiguously distinguish: no Focus is active; an active Focus together with its
+        name; the helper could not determine the state (with a machine-readable reason and a
+        human-readable explanation); and the running macOS version being unsupported.
+- [ ] A failure to determine the state is always reported explicitly — never as a silent "no Focus is
+        on".
+- [ ] When the state cannot be determined because the helper lacks Full Disk Access, the response says
+        so and tells the user exactly what to grant and where to fix it.
+- [ ] The active Focus is reported whether it was turned on manually or by a schedule/automation.
+- [ ] The helper fails gracefully — a missing, unreadable, or malformed Focus database yields an
+        explicit error, not a crash.
+- [ ] The command-line wrapper exits non-zero when the state cannot be determined (and zero otherwise),
+        so scripts can branch on the exit code without parsing the output.
+- [ ] The response conforms to a fixed, versioned, published schema (a JSON Schema) referenced from the
+        project's documentation, so consumers can validate and rely on it; the answer interface stays
+        stable even as macOS changes the underlying data format.
 
-### Consumer Logic
+### macOS Support Reporting
 
-- [ ] The response model lets a consumer decide the state with a simple, unambiguous rule
-        (exactly one of `determined`/`failed` is present):
-        if `failed` is present, the state is unknown (consult its `error`);
-        else `determined` is present and holds exactly one of `focus_off` (no Focus active) or
-        `focus_on` (a Focus is active, carrying its `name`).
-- [ ] A consumer can distinguish "no Focus is active", "an active Focus with its name",
-        "the helper failed" (including an active-but-unnameable Focus, via `focus_name_unresolved`),
-        and "the macOS version is unsupported" from each other.
+- [ ] Each response states whether the running macOS version is known-supported, known-unsupported, or
+        unknown.
+- [ ] On an unknown (unlisted) macOS version, the response asks the user to report whether it worked,
+        so coverage can be extended.
+- [ ] On a failure, the response asks the user to file an issue or PR with their macOS version, the
+        helper version, and the error.
 
-### Retrieval Logic
+### Installation, Documentation, and Adoption
 
-- [ ] Determining the Focus state follows this logic: detect the macOS version;
-        check it against the known-supported list;
-        read the active-assertions data and determine whether an active Focus assertion exists;
-        if none exists, return `determined` → `focus_off`
-        (an empty active-assertions file is a valid "Focus is off" result, not an error);
-        if one exists, extract the active Focus identifier, read the mode-configuration data,
-        and map the identifier to a human-readable Focus name (returned as `determined` → `focus_on`
-        with that `name`; if the identifier cannot be mapped, return `failed` with
-        `focus_name_unresolved`).
-- [ ] The helper accounts for the documented quirks of the Focus database (see the analysis referenced
-        below): a Focus activated by schedule or automation is reflected differently than a manually
-        toggled one, so both the active-assertions data and the mode-configuration data are consulted.
-- [ ] If the running macOS version is on neither the supported nor the unsupported list, the response
-        sets `macos_compatibility` to the `unknown` variant, carrying a "please report whether this
-        version works" `message` (whether parsing actually worked is conveyed by the outcome).
-
-### Failure Handling
-
-- [ ] The helper tolerates missing files, permission-denied files, unreadable files, malformed JSON,
-        schema changes, and partially-written files without crashing.
-- [ ] Any failure to determine the Focus state is reported explicitly as `failed` with a stable `error`
-        code (never as a `determined` result).
-- [ ] A parsing or schema failure is never reported as `determined` → `focus_off`.
-- [ ] A missing Full Disk Access grant is detected (a permission denial on the existing Focus
-        database) and reported as `failed` with a dedicated `focus_permission_denied` error code — never
-        as a `determined` result — with an actionable `message`: the canonical resolved helper binary
-        path to add and a System Settings deep link to the Full Disk Access pane.
-
-### macOS Compatibility
-
-- [ ] The project maintains an explicit macOS-version compatibility table, keyed by macOS version
-        string. An entry may be a specific point release (e.g. `15.5`) or a major-version wildcard
-        (e.g. `15.*`). A major-version wildcard is permitted only when the format-stability analysis
-        (referenced below) supports it for that major *and* the parser has been verified against at
-        least one current point release of that major.
-- [ ] The table is seeded per that analysis: macOS 12–15 are reasonable `supported` (wildcard) entries
-        once verified; macOS 11 and earlier are out of scope (a different mechanism); the current macOS
-        26 starts as `unknown` until verified.
-- [ ] On an `unknown` (unlisted) macOS version, the `macos_compatibility` `unknown` variant's `message`
-        asks the user to submit an issue or PR reporting whether this version works.
-- [ ] On a parsing failure, the response asks the user to file an issue or PR with their macOS version,
-        the helper version, and the error code.
-
-### Distribution and Documentation
-
-- [ ] The helper can be installed with a single command via build-from-source channels — Homebrew
-        (a formula in a tap) or `cargo install` — which handle the app bundle, the LaunchAgent
-        registration, and putting the CLI wrapper on the user's `PATH`. A signed + notarized Homebrew
-        cask is an optional later addition, not required here.
-- [ ] The documentation explains, prominently, exactly how to grant Full Disk Access to the helper
-        (the precise System Settings steps and the resolved binary path), and that on the
-        build-from-source channels the grant must be re-applied after each upgrade.
-- [ ] The project `README.md` clearly and concisely explains who the Focus Gopher is for, what problem
-        it solves, and how to start using it — written to engage both human and agent readers, with at
+- [ ] The helper installs with a single command (e.g. Homebrew or `cargo install`), setting itself up
+        to run and putting the command-line wrapper on the user's `PATH`.
+- [ ] The documentation explains, prominently, how to grant Full Disk Access to the helper (the precise
+        steps), including that on build-from-source installs the grant must be re-applied after an
+        upgrade.
+- [ ] The `README.md` clearly and concisely explains who the Focus Gopher is for, what problem it
+        solves, and how to start using it — written to engage both human and agent readers, with at
         least one short, deliberately slow/clear screen-recording GIF demonstrating it, and including or
         referencing (depending on length) the full `--help`/`man` documentation.
-- [ ] The `--help` output and/or `man` page are themselves clear, concise, useful to both human and
-        agent readers, and include worked examples for every common operation and its result.
+- [ ] The `--help` output and/or `man` page are clear, concise, useful to both human and agent readers,
+        and include worked examples for every common operation and its result.
 - [ ] The project ships bundled agent skills plus a simple command that installs them into the user's
         home directory or a specified project for common agent harnesses (e.g. Claude Code, Codex).
 - [ ] The project has a clear OSS license (MIT, unless a better-established commercially-friendly choice
@@ -184,17 +105,6 @@ As an agent system operator, I want a narrow macOS helper that reports the curre
 - [ ] The project has a `CONTRIBUTING.md` that orients contributors by briefly introducing the
         architecture and development workflow (largely by linking to these design docs) and by pointing
         at the repository-root `CONTRIBUTING.md`, without duplicating its content.
-
-### Testing
-
-- [ ] At least one unit or integration test covers the retrieval logic against fixture
-        Focus-database files representing Focus-on (manual and scheduled), Focus-off (including the
-        empty-file case), and malformed/unknown-schema cases, for each supported macOS major version
-        (verified against at least one current point release of each).
-- [ ] An end-to-end test verifies that a client can connect to the running helper over the socket
-        (and that the CLI wrapper works) and receive a well-formed `FocusState` (exercised against a
-        real macOS session where feasible, otherwise against fixture data with the real socket and
-        process).
 
 ## References
 
@@ -207,9 +117,10 @@ As an agent system operator, I want a narrow macOS helper that reports the curre
 ### Engineering Design
 
 - [macOS Focus Gopher Engineering Design](../engineering-designs/2026-05-12-macos-focus-gopher.md) —
-    The technical approach: a Rust helper packaged as a stable-identity `.app` LaunchAgent
+    The technical approach (the *how*): a Rust helper packaged as a stable-identity `.app` LaunchAgent
     (Developer ID signing/notarization an optional later enhancement), a Unix-domain-socket JSON
-    protocol with a thin CLI wrapper, and a versioned read-only parser of the macOS Focus database.
+    protocol with a thin CLI wrapper, the `FocusState` data model and retrieval pipeline, the
+    compatibility table, and the testing approach.
 
 ### Analysis
 

--- a/design/product-vision/2026-05-12-macos-focus-gopher.md
+++ b/design/product-vision/2026-05-12-macos-focus-gopher.md
@@ -1,0 +1,76 @@
+# macOS Focus Gopher
+
+## Problem and Motivation
+
+LLM-driven agent systems running on macOS — OpenClaw and similar automation agents —
+  often need to know the user's current Focus state
+  (is a Focus on, and if so, which one?)
+  so they can decide whether it is appropriate to interrupt, notify, or act.
+
+macOS exposes that state only through privacy-gated mechanisms.
+The underlying Focus / Do Not Disturb state lives in undocumented files under the user's home directory,
+  and reading them generally requires Full Disk Access;
+  the documented alternatives (Shortcuts, AppleScript) require Automation permissions.
+macOS grants all of these permissions to a *specific executable identity*,
+  not to "whatever is running right now".
+
+Agents are a poor fit for that model.
+They are launched through a shifting set of identities — Terminal, SSH, `uv`, Python, Node, Docker,
+  OpenClaw, frequently-rebuilt binaries, and ephemeral virtual environments —
+  so a permission granted today is attached to a binary that may not exist tomorrow.
+Worse, granting Full Disk Access (or broad Automation permissions) *to the agent itself* is dangerous:
+  agents typically have internet access, arbitrary tool use, plugins, and prompt-injection exposure,
+  so the blast radius of a compromised or manipulated agent that holds Full Disk Access is enormous.
+
+What's missing is a way for an unprivileged agent to ask a single, narrow question —
+  "what is the current Focus state?" —
+  without the agent process itself holding any broad macOS privacy permission.
+
+## Vision
+
+A small, single-purpose macOS helper — the **Focus Gopher** — that owns the macOS-specific access
+  and exposes exactly one read-only operation to local clients: `get_focus() -> FocusState`.
+
+The helper is a code-signed `.app` with a stable install path, stable bundle identifier, and stable
+  signing identity, run as a per-user LaunchAgent, so the macOS privacy permission it needs
+  (Full Disk Access, if macOS requires it) attaches to *the helper* and survives agent rebuilds,
+  reinstalls, and identity churn.
+Clients reach it over a local Unix domain socket.
+
+The helper is deliberately *not* a general-purpose automation service.
+It exposes `get_focus()` and nothing else — no `read_file(path)`, `run_shell(command)`,
+  `run_shortcut(name)`, `run_osascript(script)`, or `query_db(path)` —
+  so an agent that can talk to the Focus Gopher gains the ability to read Focus state and no other capability.
+
+Because the macOS Focus database format is undocumented and changes between releases,
+  the helper's value is its *stable interface*, not the schema it parses.
+The response model separates orthogonal facts — whether the helper succeeded, whether a Focus is enabled,
+  whether a Focus name is available, and whether this macOS version is known-supported —
+  so consumers never have to guess, and a parsing failure is reported as an explicit error
+  rather than silently masquerading as "no Focus is on".
+The helper ships a macOS-version compatibility table, asks users to report unknown-but-working versions,
+  and asks for an issue or PR (with version and error details) when parsing fails on a new release.
+
+## Success Metrics
+
+- An agent can retrieve the current Focus state (on/off, and the Focus name when on)
+    via a single local call, without holding Full Disk Access or any other broad macOS privacy permission.
+- Rebuilding, reinstalling, or relaunching the agent — or changing how it is launched —
+    does not break Focus retrieval, because no macOS permission is attached to the agent's identity.
+- The helper has a stable macOS identity: a fixed install path, bundle ID, and signing identity,
+    updated infrequently.
+- The helper exposes exactly one read-only operation and no arbitrary filesystem, shell, Shortcut,
+    or AppleScript access.
+- The helper's responses unambiguously distinguish *no Focus is on*, *a Focus is on* (with or without
+    a resolved name), and *the state could not be determined*; a parsing failure is never reported as
+    "no Focus is on".
+- The helper reports whether the running macOS version is known-supported, and emits actionable
+    guidance on unknown-but-working versions and on parsing failures.
+
+## Requirements
+
+This vision is being implemented through the following requirements:
+
+- [macOS Focus Gopher](../product-requirements/2026-05-12-macos-focus-gopher.md) —
+    A per-user macOS helper that reports the current Focus state over a local socket
+    behind a narrow, read-only `get_focus()` API (draft).

--- a/design/product-vision/2026-05-12-macos-focus-gopher.md
+++ b/design/product-vision/2026-05-12-macos-focus-gopher.md
@@ -31,10 +31,13 @@ What's missing is a way for an unprivileged agent to ask a single, narrow questi
 A small, single-purpose macOS helper — the **Focus Gopher** — that owns the macOS-specific access
   and exposes exactly one read-only operation to local clients: `get_focus() -> FocusState`.
 
-The helper is a code-signed (and notarized) app with a stable install path, stable bundle identifier,
-  and stable signing identity, run as a per-user LaunchAgent, so the macOS privacy permission it needs
-  (Full Disk Access, if macOS requires it) attaches to *the helper* and survives agent rebuilds,
+The helper is a stable-identity app with a fixed install path and bundle identifier,
+  run as a per-user LaunchAgent, so the macOS privacy permission it needs
+  (Full Disk Access) attaches to *the helper* and survives agent rebuilds,
   reinstalls, and identity churn.
+Developer ID code signing and notarization are an optional later enhancement that additionally lets the
+  helper's own grant persist across the helper's *own* upgrades; they are not required for the core
+  value above, and the helper is fully functional when built from source and granted access manually.
 Clients reach it over a local Unix domain socket; a thin command-line wrapper ships alongside it
   for callers (humans and agents) who prefer to just run a command.
 
@@ -63,8 +66,9 @@ The Focus Gopher should also be *pleasant to discover and adopt*: easy to instal
     via a single local call, without holding Full Disk Access or any other broad macOS privacy permission.
 - Rebuilding, reinstalling, or relaunching the agent — or changing how it is launched —
     does not break Focus retrieval, because no macOS permission is attached to the agent's identity.
-- The helper has a stable macOS identity: a fixed install path, bundle ID, and signing identity,
-    updated infrequently.
+- The helper has a stable macOS identity: a fixed install path and bundle ID, updated infrequently
+    (with an optional Developer ID signing identity that additionally persists the grant across the
+    helper's own upgrades).
 - The helper exposes exactly one read-only operation and no arbitrary filesystem, shell, Shortcut,
     or AppleScript access.
 - The helper's responses unambiguously distinguish *no Focus is on*, *a Focus is on* (with or without

--- a/design/product-vision/2026-05-12-macos-focus-gopher.md
+++ b/design/product-vision/2026-05-12-macos-focus-gopher.md
@@ -48,12 +48,13 @@ It exposes `get_focus()` and nothing else — no `read_file(path)`, `run_shell(c
 
 Because the macOS Focus database format is undocumented and changes between releases,
   the helper's value is its *stable interface*, not the schema it parses.
-The response model separates orthogonal facts — whether the helper succeeded, whether a Focus is enabled,
-  whether a Focus name is available, and whether this macOS version is known-supported —
-  so consumers never have to guess, and a parsing failure is reported as an explicit error
-  rather than silently masquerading as "no Focus is on".
-The helper ships a macOS-version compatibility table, asks users to report unknown-but-working versions,
-  and asks for an issue or PR (with version and error details) when parsing fails on a new release.
+The response model keeps the possible outcomes distinct — a Focus is on (with its name), no Focus is on,
+  or the state could not be determined — so consumers never have to guess, and a parsing failure (or an
+  active Focus whose name cannot be resolved) is reported as an explicit error rather than silently
+  masquerading as "no Focus is on".
+The helper ships a macOS-version compatibility table, asks users to report whether unlisted ("unknown")
+  versions work, and asks for an issue or PR (with version and error details) when parsing fails on a
+  new release.
 
 The Focus Gopher should also be *pleasant to discover and adopt*: easy to install, well-documented for
   both human and agent readers, and obviously useful at a glance.
@@ -71,11 +72,11 @@ The Focus Gopher should also be *pleasant to discover and adopt*: easy to instal
     helper's own upgrades).
 - The helper exposes exactly one read-only operation and no arbitrary filesystem, shell, Shortcut,
     or AppleScript access.
-- The helper's responses unambiguously distinguish *no Focus is on*, *a Focus is on* (with or without
-    a resolved name), and *the state could not be determined*; a parsing failure is never reported as
-    "no Focus is on".
+- The helper's responses unambiguously distinguish *no Focus is on*, *a Focus is on* (with its name),
+    and *the state could not be determined* (including an active Focus whose name cannot be resolved);
+    a parsing failure is never reported as "no Focus is on".
 - The helper reports whether the running macOS version is known-supported, and emits actionable
-    guidance on unknown-but-working versions and on parsing failures.
+    guidance on unlisted ("unknown") versions and on parsing failures.
 
 ### Discoverability and adoption
 

--- a/design/product-vision/2026-05-12-macos-focus-gopher.md
+++ b/design/product-vision/2026-05-12-macos-focus-gopher.md
@@ -31,11 +31,12 @@ What's missing is a way for an unprivileged agent to ask a single, narrow questi
 A small, single-purpose macOS helper — the **Focus Gopher** — that owns the macOS-specific access
   and exposes exactly one read-only operation to local clients: `get_focus() -> FocusState`.
 
-The helper is a code-signed `.app` with a stable install path, stable bundle identifier, and stable
-  signing identity, run as a per-user LaunchAgent, so the macOS privacy permission it needs
+The helper is a code-signed (and notarized) app with a stable install path, stable bundle identifier,
+  and stable signing identity, run as a per-user LaunchAgent, so the macOS privacy permission it needs
   (Full Disk Access, if macOS requires it) attaches to *the helper* and survives agent rebuilds,
   reinstalls, and identity churn.
-Clients reach it over a local Unix domain socket.
+Clients reach it over a local Unix domain socket; a thin command-line wrapper ships alongside it
+  for callers (humans and agents) who prefer to just run a command.
 
 The helper is deliberately *not* a general-purpose automation service.
 It exposes `get_focus()` and nothing else — no `read_file(path)`, `run_shell(command)`,
@@ -51,7 +52,12 @@ The response model separates orthogonal facts — whether the helper succeeded, 
 The helper ships a macOS-version compatibility table, asks users to report unknown-but-working versions,
   and asks for an issue or PR (with version and error details) when parsing fails on a new release.
 
+The Focus Gopher should also be *pleasant to discover and adopt*: easy to install, well-documented for
+  both human and agent readers, and obviously useful at a glance.
+
 ## Success Metrics
+
+### Core capability
 
 - An agent can retrieve the current Focus state (on/off, and the Focus name when on)
     via a single local call, without holding Full Disk Access or any other broad macOS privacy permission.
@@ -67,10 +73,23 @@ The helper ships a macOS-version compatibility table, asks users to report unkno
 - The helper reports whether the running macOS version is known-supported, and emits actionable
     guidance on unknown-but-working versions and on parsing failures.
 
+### Discoverability and adoption
+
+- It is easy for the intended audiences — both human and agent — to find, install, understand, and
+    start using the Focus Gopher (including a one-command install and clear, example-rich docs for both
+    audiences).
+- The project markets itself well: a clear, engaging README that explains who it's for and what it
+    solves, a working demonstration, and an obvious path from "never heard of it" to "using it".
+
+The concrete shape of these — Homebrew install, README content and demo media, `--help`/`man` docs, a
+  published JSON Schema for `FocusState`, bundled agent skills, an OSS license, and a CONTRIBUTING entry
+  point — is specified in the [product requirement](../product-requirements/2026-05-12-macos-focus-gopher.md)
+  and [engineering design](../engineering-designs/2026-05-12-macos-focus-gopher.md), not here.
+
 ## Requirements
 
 This vision is being implemented through the following requirements:
 
 - [macOS Focus Gopher](../product-requirements/2026-05-12-macos-focus-gopher.md) —
     A per-user macOS helper that reports the current Focus state over a local socket
-    behind a narrow, read-only `get_focus()` API (draft).
+    (with a thin CLI wrapper) behind a narrow, read-only `get_focus()` API (draft).


### PR DESCRIPTION
## Summary

Bring the **macOS Focus Gopher** — a small per-user macOS helper that lets an unprivileged local client (e.g. an LLM/agent system like OpenClaw) read the current macOS Focus state behind a narrow, read-only `get_focus()` API, over a local Unix domain socket with a thin CLI wrapper — into the repo's `design/` process before implementation begins.

- Adds the product vision, product requirement, engineering design, and delivery plan for the Focus Gopher (the project would live at the repo root as `macos-focus-gopher/`).
- Adds three supporting analyses: the macOS Focus DB format & stability, the `FocusState` JSON response shape (flat vs. tagged union), and Full Disk Access / code-signing / distribution channels.
- Specifies `FocusState` as an externally-tagged discriminated union that mirrors the helper's internal sum type (`determined` → `focus_on`/`focus_off`, or `failed` with an enumerated error code), and defers Developer ID signing + notarization to an optional later milestone — build-from-source (`cargo install` / Homebrew) ships first, with graceful missing-Full-Disk-Access handling as a first-class early concern.
- Adds two engineering principles (Least Privilege; Clear, Unambiguous, Easily-Parsed Data Models) and refines two existing ones (Strong Typing — illegal states stay unrepresentable across the serialization boundary; Comprehensive Error Modeling — boundary errors are enumerated domain types) plus the delivery-plan "honest deferral" guidance.
- Pins the helper's bundle identifier to `justdavis.FocusGopher`.

## Design Process

- [Product Vision: macOS Focus Gopher](design/product-vision/2026-05-12-macos-focus-gopher.md)
- [Product Requirement: macOS Focus Gopher](design/product-requirements/2026-05-12-macos-focus-gopher.md)
- [Engineering Design: macOS Focus Gopher](design/engineering-designs/2026-05-12-macos-focus-gopher.md)
- [Delivery Plan: macOS Focus Gopher](design/delivery-plans/2026-05-12-macos-focus-gopher.md)
- Analyses:
  - [macOS Focus Database Format and Stability](design/analyses/2026-05-12-macos-focus-db-format.md)
  - [`FocusState` JSON Response Shape: Flat vs. Tagged Union](design/analyses/2026-05-12-focus-state-json-shape.md)
  - [macOS Full Disk Access, Code Signing, and Distribution Channels](design/analyses/2026-05-18-macos-fda-distribution-signing.md)
- Engineering principles added: [Least Privilege](design/engineering-principles/2026-05-12-least-privilege.md); [Clear, Unambiguous, Easily-Parsed Data Models](design/engineering-principles/2026-05-12-clear-data-models.md)
- Engineering principles refined: [Strong Typing and Information Preservation](design/engineering-principles/2026-01-07-strong-typing.md); [Comprehensive Error Modeling](design/engineering-principles/2026-01-08-error-modeling.md)

## Success Criteria

### General Criteria

- [x] **All CI checks pass**: Tests pass, linting succeeds, formatting correct.
- [x] **Code review recommendations addressed**: All review feedback implemented.
- [x] **No stubbed/incomplete code**: N/A — this PR is design documentation only; it adds no code.
- [x] **No TODO/FIXME without tracking**: No TODOs/FIXMEs introduced.
- [ ] **Deferred work tracked in GitHub issues**: Implementation is intentionally deferred; the delivery plan sequences the milestones, and tracking issues will be filed when implementation begins.
- [x] **Follows Engineering Principles**: The docs align with the engineering principles, add two, and refine two more.

### Documentation Criteria

- [x] Markdown formatting follows project guidelines.
- [x] All links verified working (one stale analysis-reference title was caught in review and corrected).
- [x] Spelling and grammar checked.

## Test Plan

- Documentation-only change; no automated tests apply.
- Verified each new doc follows its template (`design/product-vision/template.md`, `design/product-requirements/template.md`, `design/engineering-designs/template.md`, `design/engineering-principles/template.md`) and, for the delivery plan, the `design/delivery-plans/README.md` guidance.
- Verified the cross-links among the docs resolve, and ran a coherence pass over the full set (data model, signing deferral, compatibility model, and the user-facing/builder split) after the review rounds.
- Hand-checked markdown style (one sentence per line, ~110-char wrap, periods on list items, blank line above headers, trailing newline); the only lines exceeding 110 chars are Markdown links and JSON inside code blocks, which the style rules exempt. (`mise` is not available in this environment, so no markdown linter was run.)

## Context

macOS privacy permissions (Full Disk Access, Accessibility, Screen Recording, Automation) are granted to a specific executable identity. Agent systems are launched from a churning set of identities (Terminal, SSH, `uv`, Python, Node, Docker, OpenClaw, frequently-rebuilt binaries, ephemeral virtual environments), so a permission granted today is attached to a binary that may not exist tomorrow — and granting an internet-connected, tool-using, prompt-injectable agent Full Disk Access has an enormous blast radius. The Focus Gopher is a narrow, stable-identity broker: it holds whatever permission macOS requires, performs the privileged read-only parse of the undocumented `~/Library/DoNotDisturb/DB/*.json` files itself, and hands clients only a fixed-schema `FocusState`. This PR captures that design (vision → requirement → engineering design → delivery plan), the three analyses that underpin its riskier decisions, and the engineering principles the discussion surfaced; implementation will follow per the delivery plan.