### PR TITLE
docs: align design-process issue templates with the merged-doc workflow

### DIFF
--- a/.claude/rules/github-issues.md
+++ b/.claude/rules/github-issues.md
@@ -17,7 +17,12 @@ Use GitHub issues to track all planned work, deferred features, and known bugs.
 - Add appropriate labels for categorization.
 
 **Available issue templates:** bug report, product requirement,
-  product vision, maintenance.
+  product vision, delivery plan milestone, maintenance.
+
+The product-vision, product-requirement, and delivery-plan-milestone templates
+  treat the corresponding `design/` document as the source of truth:
+  the issue links the document and tracks the work,
+  rather than restating the document's content (which would drift).
 
 ## Linking Issues to PRs
 

--- a/.github/ISSUE_TEMPLATE/delivery_plan_milestone.md
+++ b/.github/ISSUE_TEMPLATE/delivery_plan_milestone.md
@@ -1,0 +1,42 @@
+---
+name: Delivery Plan Milestone
+about: Track a single milestone from a delivery plan
+title: ''
+labels: milestone
+assignees: ''
+---
+
+<!--
+Delivery plans live as documents in `design/delivery-plans/`, authored and merged
+  through the design process (see `design/README.md`).
+The plan is the source of truth: link the specific milestone below and keep its
+  full in-scope/deferred breakdown there, rather than restating it in this issue,
+  so the two cannot drift.
+Link this issue as a sub-issue of the product requirement (or vision) it delivers.
+-->
+
+## Delivery Plan & Milestone
+
+Link the delivery plan and the specific milestone this issue tracks:
+
+- `design/delivery-plans/YYYY-MM-DD-short-name.md` — **Milestone N**
+
+## Scope
+
+One or two sentences on what this milestone delivers,
+  enough to triage this issue without opening the plan.
+The full in-scope and deferred breakdown lives in the plan.
+
+## Deliverable
+
+The concrete, demonstrable outcome that marks this milestone done
+  (the plan's "Deliverable" for this milestone).
+
+## Acceptance Criteria
+
+- [ ] (Add this milestone's specific criteria.)
+- [ ] All CI checks pass.
+
+## Additional Context
+
+Any other context or references not already in the plan.

--- a/.github/ISSUE_TEMPLATE/product_requirement.md
+++ b/.github/ISSUE_TEMPLATE/product_requirement.md
@@ -1,28 +1,40 @@
 ---
 name: Product Requirement
-about: Propose a new product requirement for implementation
+about: Propose or track a product requirement
 title: ''
 labels: requirement
 assignees: ''
 ---
 
+<!--
+Product requirements live as documents in `design/product-requirements/`, authored
+  and merged through the design process (see `design/README.md`).
+That document — with its user story and acceptance criteria — is the source of truth:
+  link it below and keep the detail there, rather than restating it in this issue,
+  so the two cannot drift.
+The document may already be merged, or this issue may drive its first draft —
+  both are fine.
+-->
+
+## Requirement Document
+
+Link the requirement document in `design/product-requirements/`
+  (or note that it does not exist yet — adopting this issue can drive its creation,
+  or its first draft can land in the same pull request):
+
+- `design/product-requirements/YYYY-MM-DD-short-name.md`
+
 ## Summary
 
-One paragraph of what this requirement would deliver and why it matters.
-
-## User Story
-
-As a [user type], I want [capability] so that [benefit].
-
-## Acceptance Criteria
-
-- [ ] Criterion 1.
-- [ ] Criterion 2.
-- [ ] At least one unit or integration test covers the functionality.
+One or two sentences on what this requirement delivers and why it matters,
+  enough to triage this issue without opening the document.
+The full user story and acceptance criteria live in the document above.
 
 ## Related Vision
 
-Link to product vision doc, if any (e.g., `design/product-vision/YYYY-MM-DD-name.md`).
+Link the product vision this serves, if any:
+
+- `design/product-vision/YYYY-MM-DD-short-name.md`
 
 ## Priority
 
@@ -30,11 +42,12 @@ Link to product vision doc, if any (e.g., `design/product-vision/YYYY-MM-DD-name
 - [ ] Medium — Should be addressed soon.
 - [ ] Low — Nice to have, can be deferred.
 
+## Status / Next Steps
+
+What needs to happen next?
+For example: draft or revise the requirement document,
+  break it into delivery-plan milestones, or begin implementation.
+
 ## Additional Context
 
-Any other context, mockups, or references.
-
----
-
-When implemented, this issue drives creation of a `YYYY-MM-DD-short-name.md` file
-in `design/product-requirements/`.
+Any other context, mockups, or references not already in the document.

--- a/.github/ISSUE_TEMPLATE/product_vision.md
+++ b/.github/ISSUE_TEMPLATE/product_vision.md
@@ -1,38 +1,39 @@
 ---
 name: Product Vision
-about: Propose high-level product direction
+about: Propose or track a product vision
 title: ''
 labels: vision
 assignees: ''
 ---
 
-## Vision Statement
+<!--
+Product visions live as documents in `design/product-vision/`, authored and merged
+  through the design process (see `design/README.md`).
+That document is the source of truth: link it below and keep the detail there,
+  rather than restating it in this issue, so the two cannot drift.
+The document may already be merged, or this issue may drive its first draft —
+  both are fine.
+-->
 
-One paragraph of the long-term direction.
+## Vision Document
 
-## Problem / Opportunity
+Link the vision document in `design/product-vision/`
+  (or note that it does not exist yet — adopting this issue can drive its creation,
+  or its first draft can land in the same pull request):
 
-What user problems or needs are being addressed?
+- `design/product-vision/YYYY-MM-DD-short-name.md`
 
-## Success Metrics
+## Summary
 
-How to measure whether the vision is being realized.
+One or two sentences on the direction and the problem it addresses,
+  enough to triage this issue without opening the document.
 
-- Metric 1.
-- Metric 2.
+## Status / Next Steps
 
-## Initial Requirements
-
-Bullet list of capabilities that would implement this vision.
-
-- Capability 1.
-- Capability 2.
+What needs to happen next?
+For example: draft or revise the vision document,
+  derive product requirements from it, or start a delivery plan.
 
 ## Additional Context
 
-Any other context, research, or references.
-
----
-
-When adopted, this issue drives creation of a vision document
-in `design/product-vision/`.
+Any other context, research, or references not already in the document.


### PR DESCRIPTION
## Summary

For contributors filing design-process issues (visions, requirements, delivery-plan milestones): the issue templates assumed the corresponding `design/` doc didn't exist yet, so they asked you to capture the *entire* artifact in the issue body and framed the issue as the precursor that "drives creation of" the doc. But in this repo's design process the docs in `design/` are authored and merged via PR and are the source of truth — so an issue ended up duplicating, and risking drift from, an already-merged document.

- Reframes `product_vision.md` and `product_requirement.md` as a lightweight pointer/tracker: link the design doc (already-merged *or* to-be-drafted), keep only a short triage summary plus status/priority/context, and leave the detail in the document.
- Adds a new **`Delivery Plan Milestone`** template (`delivery_plan_milestone.md`) for tracking individual milestones from a `design/delivery-plans/` doc, in the same doc-as-source-of-truth shape (links the specific milestone; tracks scope/deliverable/acceptance criteria). Labels such issues `milestone`.
- Updates `.claude/rules/github-issues.md` to list the new template and to record that the vision/requirement/milestone templates treat the design doc as the source of truth.
- `bug_report.md` and `maintenance.md` are untouched.

## Design Process

No new design docs. This adjusts repository tooling (issue templates + the github-issues rule) to match the existing design process described in [`design/README.md`](design/README.md) and [`.claude/rules/design-process.md`](.claude/rules/design-process.md).

## Success Criteria

### General

- [x] **All CI checks pass**: this PR only touches `.github/ISSUE_TEMPLATE/*.md` and `.claude/rules/github-issues.md`; no code paths are affected.
- [ ] **Code review recommendations addressed**: pending the automated review (this PR carries `claude-review`) and any human review.
- [x] **No stubbed/incomplete code**: N/A — documentation/templates only.
- [x] **No TODO/FIXME without tracking**: none added.
- [x] **Deferred work tracked in GitHub issues**: N/A — self-contained change.
- [x] **Follows Engineering Principles**: keeps a single source of truth (the design doc) and removes the duplicated projection that could drift.

### Documentation

- [x] **Markdown formatting follows project guidelines**: templates follow the markdown-style rules; instructional text is in HTML comments (shown in the issue-creation textarea, hidden in the rendered issue).
- [x] **All links verified working**: the referenced paths under `design/` exist.
- [x] **Spelling and grammar checked**.

## Test Plan

- Verified each template's YAML front-matter (`name`/`about`/`labels`) is intact so GitHub keeps listing them in the issue chooser.
- Created the referenced labels on the repo so the templates' `labels:` resolve: `vision`, `requirement`, and `milestone` (these did not previously exist, so template-created issues would have silently dropped their label).
- Confirmed the diff is limited to the three template files and the github-issues rule.
- Dogfooded the new shapes by filing the Focus Gopher tracking issues (vision #23 → requirement #24 → milestones #16–#21).

## Context

Follow-up to the Focus Gopher M1 PR (#15). While wiring the delivery plan into GitHub issues (#16–#21, under requirement #24 and vision #23), the templates' "capture everything in the issue" framing — and the absence of any milestone template — stood out as out of step with the merged-doc-as-source-of-truth design process. Kept as its own PR per request.