### PR TITLE
docs: allow current/past milestone refs in PR and commit metadata

### DIFF
--- a/.claude/rules/delivery-milestones.md
+++ b/.claude/rules/delivery-milestones.md
@@ -1,23 +1,53 @@
 # Referencing Delivery Milestones
 
 Delivery-plan milestones (M1, M2, …) are a planning device, and plans shift.
-A comment or doc that says "this lands in M3" rots the moment the plan is resequenced,
-  and nobody remembers to update it.
+References to milestones can rot in two distinct ways:
+
+- *Future* milestone references rot because the plan can be resequenced;
+    "this lands in M5" stops being true the moment the work is moved to M4 or M6.
+- *Past* and *current* milestone references in long-lived content rot because the *code*
+    keeps changing;
+    a comment that says "stubbed for M2, real impl in M3"
+    stays in the file after a later milestone rewrites the same function,
+    and the comment now mis-ascribes the function's behavior to the wrong milestone.
+
+Point-in-time content
+  (PR titles, PR descriptions, commit messages)
+  doesn't suffer from the second failure mode,
+  because it's a record of a single moment and is never re-edited.
 
 ## The Rule
 
+### Long-Lived Content — Code, Comments, Project Docs, Design Docs
+
 - Do **not** hard-code specific delivery-milestone identifiers (M2, M3, …)
-    in code, comments, or project docs.
+    in code, code comments / doc-comments, project docs, or design docs.
 - Describe *state and intent* instead:
     "stubbed for now", "the real implementation comes later", "a later milestone", etc.
 - *General* references to the design docs or the delivery plan are encouraged
     — they stay correct as the plan evolves.
 - The delivery plan and its milestone tracking issues are the single source of truth
-    for the milestone breakdown; link to them rather than restating the list.
+    for the milestone breakdown;
+    link to them rather than restating the list.
 
-## Exception
+#### Exception
 
 A project's own `README.md` **may** name the **current** milestone
   (for example, to mark "this state"),
-  because that describes the present, not a forecast.
-Future milestones still should not be enumerated outside the delivery plan and its issues.
+  because that describes the present, not a forecast,
+  and a README is consciously updated as project state changes.
+Future and past milestones still should not be enumerated in long-lived content
+  outside the delivery plan and its issues.
+
+### Point-in-Time Content — PR Titles/Descriptions, Commit Messages
+
+PRs and commits are records of a specific moment and are never re-edited,
+  so the second failure mode (comment-vs.-code drift) doesn't apply.
+
+- Naming the **current** milestone (the one a PR implements) is fine,
+    including in the squash-commit subject and body that the PR will produce.
+- Naming **past** completed milestones is also fine,
+    e.g. "replaces the M2 stub" or "fixes a regression introduced in M4".
+- **Future** milestone identifiers are still prohibited
+    — those rot the same way they do in long-lived content.
+  Describe state and intent: "a later milestone", "as those versions are verified", etc.


### PR DESCRIPTION
## Summary

Splits the `delivery-milestones` rule into two cases so that PR/commit metadata can name the milestone they implement (current) or build on (past), while long-lived content (code, comments, project docs, design docs) stays strictly state-and-intent.

- Long-lived content keeps the old prohibition because the *code* keeps changing — a comment saying "stubbed for M2, real impl in M3" stays in the file after a later milestone rewrites the function, mis-ascribing the new behavior to the wrong milestone.
- Point-in-time content (PR titles/descriptions, commit messages) is a record of a single moment and is never re-edited, so that failure mode doesn't apply.
- Future-milestone identifiers stay prohibited everywhere — those rot because the plan can be resequenced.
- The existing README current-milestone exception is preserved verbatim in intent.

## Design Process

No design process docs apply — this is a rule (`.claude/rules/`) update, prompted by a concrete review finding rather than originating in the design pipeline.

## Success Criteria

### General

- [x] **All CI checks pass**: docs-only change; CI just runs markdown/formatting (no code touched).
- [x] **Code review recommendations addressed**: self-review acceptable for a small docs change per [`pr-workflow.md`](.claude/rules/pr-workflow.md).
- [x] **No stubbed/incomplete code**: N/A — docs only.
- [x] **No TODO/FIXME without tracking**: none introduced.
- [x] **Deferred work tracked in GitHub issues**: none deferred.
- [x] **Follows Engineering Principles**: N/A — rule file.

### Documentation criteria

- [x] **Markdown formatting follows project guidelines**: one sentence per line, 110-char wrap, 2-space continuation indent per [`markdown-style.md`](.claude/rules/markdown-style.md).
- [x] **All links verified working**: no new links introduced.
- [x] **Spelling and grammar checked**.

## Test Plan

- Re-read the rewritten rule and walked through each milestone reference in PR #29's title and body — the four current/past references (`(M3)`, `M2 stub`, `Milestone 3`, `M3 milestone acceptance criteria`) are now allowed in point-in-time content, while the two future references (`milestone M5`, `land incrementally in M5`) remain prohibited under both the long-lived and point-in-time sections.
- Walked through the iteration-3 cleanups in PR #29 (which removed `M3` from `compatibility.rs`, `focus.rs`, `FIXTURES.md`, and the format-stability analysis) — those remain correct under the new rule because all four files are long-lived content and none are a project README.
- `git grep -nE '\bM[0-9]+\b|Milestone [0-9]'` across the worktree (excluding `design/delivery-plans/`, the source of truth) confirms there are still no in-repo hard-coded identifiers.

## Context

Prompted by [the review-bot comment on #29](https://github.com/justdavis-family/justdavis/pull/29#issuecomment-4550980420), which correctly flagged a rule violation but exposed that the rule was over-broad: it treated PR/commit metadata the same as code, even though the two surfaces rot for different reasons. The bot's finding on the *future* `M5` references stays valid and will be addressed in #29's description before merge.