### PR TITLE
feat: add a design-process skill, delivery-plan template, and issue-tracking docs

### DIFF
--- a/.claude/rules/github-issues.md
+++ b/.claude/rules/github-issues.md
@@ -19,6 +19,18 @@ Use GitHub issues to track all planned work, deferred features, and known bugs.
 **Available issue templates:** bug report, product requirement,
   product vision, maintenance.
 
+## Design-Process Tracking Issues
+
+Work that follows the [design process](/design/README.md) is tracked with a matching hierarchy of
+  issues: a `vision` issue, a `requirement` issue, and — when there is a delivery plan —
+  one `milestone` sub-issue per milestone.
+The design documents stay authoritative for *content*;
+  these issues are authoritative for *status*.
+
+See [`design/delivery-plans/README.md`](/design/delivery-plans/README.md)
+  for the title formats, labels, issue-body structure,
+  and guidance on how requirements, milestones, and PRs correspond.
+
 ## Linking Issues to PRs
 
 - Reference related issues in PR descriptions using `#issue-number` syntax.

--- a/.claude/skills/design-process/SKILL.md
+++ b/.claude/skills/design-process/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: design-process
+description: >-
+  Routes you through this monorepo's design process — analysis, product vision, product requirements,
+  engineering design, and delivery plan — and to the templates, conventions, and tracking issues each
+  step needs. Use this whenever starting a new project, feature, or significant enhancement in this
+  repo; whenever writing or reviewing anything under `design/`; whenever asked to "write a design doc",
+  "plan out" a feature, or "follow the design process"; and whenever you are about to start
+  implementing something substantial and are not sure whether design docs should come first.
+---
+
+# Design Process
+
+This repo drives non-trivial work through a documented design process.
+This skill tells you **which document to write, in what order, and where its rules live**.
+
+The authoritative content lives in `design/` — this skill routes, it does not restate.
+When this skill and a `README.md` disagree, the README wins;
+  fix the skill.
+
+## First: does this work need the process at all?
+
+- **New features and significant enhancements** — yes, design docs come before (or alongside) the code.
+- **Simple bug fixes, maintenance, and infrastructure changes** — no, go straight to implementation.
+
+Don't over-apply this. A one-line fix does not need a vision document.
+
+## The sequence
+
+Work forward through these. Skip a step only when you can say why it doesn't apply.
+
+| Step | Directory | Rules | Template |
+|---|---|---|---|
+| 1. Analysis *(when needed)* | `design/analyses/` | [README](../../../design/analyses/README.md) | none — see existing analyses |
+| 2. Product Vision | `design/product-vision/` | [README](../../../design/product-vision/README.md) | [template.md](../../../design/product-vision/template.md) |
+| 3. Product Requirements | `design/product-requirements/` | [README](../../../design/product-requirements/README.md) | [template.md](../../../design/product-requirements/template.md) |
+| 4. Engineering Design | `design/engineering-designs/` | [README](../../../design/engineering-designs/README.md) | [template.md](../../../design/engineering-designs/template.md) |
+| 5. Delivery Plan *(when multi-PR)* | `design/delivery-plans/` | [README](../../../design/delivery-plans/README.md) | [template.md](../../../design/delivery-plans/template.md) |
+
+[`design/README.md`](../../../design/README.md) has the full workflow diagram and the naming conventions.
+
+Two supporting document types sit outside the sequence:
+
+- [`design/engineering-principles/`](../../../design/engineering-principles/README.md) —
+    cross-cutting standards that designs and code should align with.
+  Consult the index in [`.claude/rules/engineering-principles.md`](../../rules/engineering-principles.md)
+    while designing; add a principle only when it is generalizable, non-obvious, and has real trade-offs.
+- [`design/notes/`](../../../design/notes/) — half-baked ideas that aren't ready to be anything else.
+
+## When to write an analysis
+
+Analyses come *before* design decisions, and exist to evaluate options.
+Write one when a significant decision has multiple viable options,
+  or when the design depends on facts you'd otherwise be guessing at
+  (an undocumented file format, a third-party API's real behavior, whether an approach is even feasible).
+
+Straightforward choices don't need one.
+The test is whether a reader would otherwise have to take your conclusion on faith.
+
+Analyses are durable and committed — they explain *why* a design is what it is,
+  long after the alternatives have been forgotten.
+If a claim in an analysis was inherited from elsewhere rather than verified,
+  say so explicitly and say what would settle it.
+
+## Distinctions that are easy to get wrong
+
+These trip people up repeatedly, so check yourself against them.
+
+**A requirement is one user story that fits in one PR.**
+The litmus test is: *does this affect the product's capabilities or quality for users?*
+If yes, it's a requirement.
+If it only affects how developers work on the product, it isn't —
+  process docs, repo setup, and agent instructions are not requirements.
+Signs a requirement is too big: it contains multiple user stories,
+  its acceptance criteria span unrelated areas,
+  or a PR could reasonably implement only part of it.
+Once implemented, requirements are immutable —
+  supersede them with new, cross-linked ones rather than editing them.
+
+**A delivery plan is not a task list.**
+It answers "what are the milestones, and what does each one deliver?" —
+  not the steps inside each PR, which are left to whoever does the work.
+Its real value is scope management: deciding what goes in each PR *before* development,
+  so over-commitment surfaces early.
+
+**Milestones must be thin vertical slices.**
+Each one delivers something independently usable,
+  not an intermediate state that only makes sense in hindsight.
+A good test: could the reader stop after any milestone and still have something worth having?
+
+**An engineering design is evergreen; a requirement is a snapshot.**
+Update designs as the system evolves.
+Don't retroactively edit implemented requirements.
+
+## Naming and formatting
+
+- Single-file: `YYYY-MM-DD-short-name.md`.
+  Multi-file: a `YYYY-MM-DD-short-name/` directory with `README.md` as the main document.
+- Title ≤10 words; short name 3–5 kebab-case words condensing the title;
+    ISO 8601 dates; kebab-case throughout.
+- Every document ends with a `References` section cross-linking the others by relative path.
+  The templates show the expected shape.
+- Follow [`.claude/rules/markdown-style.md`](../../rules/markdown-style.md) —
+    one sentence per line, 110-character wrap, two-space continuation indent, periods on list items.
+  This is enforced by review, and it makes prose diffs readable.
+
+## Tracking and shipping the work
+
+- **Tracking issues** mirror the documents: a `vision` issue, a `requirement` issue,
+    and — when there's a delivery plan — one `milestone` sub-issue per milestone.
+  Documents are authoritative for *content*; issues for *status*.
+  Formats and structure are in
+    [`design/delivery-plans/README.md`](../../../design/delivery-plans/README.md).
+- **Don't hard-code future milestone identifiers** in code, comments, or long-lived docs — plans shift.
+  See [`.claude/rules/delivery-milestones.md`](../../rules/delivery-milestones.md)
+    for exactly where naming a milestone is and isn't acceptable.
+- **Everything ships through a PR**, including design docs.
+  See [`.claude/rules/pr-workflow.md`](../../rules/pr-workflow.md)
+    for branch naming, the required PR description outline, the Success Criteria checklist,
+    and the squash-merge convention.
+
+## Authoring a full lineage
+
+When writing several documents for one project, prefer **one PR with a commit per document**,
+  pausing for review between them.
+Each document constrains the next,
+  so a review that lands after the whole set is written is a review that arrives too late to help.
+
+Work in a git worktree under `.claude/worktrees/<branch>/` (already gitignored) to keep the
+  main checkout usable.
+Check `.worktreeinclude` for gitignored files that need copying into new worktrees.
+
+Write documents in dependency order and let each one genuinely constrain the next.
+If while writing a requirement you find the vision doesn't support it,
+  fix the vision rather than quietly widening the requirement.
+That backpressure is the point of the sequence.

--- a/design/delivery-plans/README.md
+++ b/design/delivery-plans/README.md
@@ -43,6 +43,69 @@ Simple, clearly-scoped requirements that fit comfortably in one PR do not need a
 - **Human decisions recorded**: the plan captures choices about sequencing and scope
     that aren't obvious from the requirements themselves.
 
+## Tracking Delivery in GitHub Issues
+
+Design documents and GitHub issues play different roles, and the split matters:
+
+- **The documents are authoritative for content.**
+  What a requirement means, and what each milestone contains, lives in the docs.
+- **The issues are authoritative for status.**
+  Whether something is in progress, blocked, or done lives in the issue tracker.
+
+Issues therefore *summarize and link* their documents rather than restating them.
+When the two disagree about content, the document wins and the issue should be corrected.
+
+### The Issue Hierarchy
+
+Three levels of tracking issue mirror the design documents,
+  each carrying a label matching its document type:
+
+| Issue | Title format | Label | Mirrors |
+|---|---|---|---|
+| Vision | `<Project> — product vision` | `vision` | A product vision document. |
+| Requirement | `<Project> — product requirement` | `requirement` | A product requirement document. |
+| Milestone | `<Project> M<N> — <milestone title>` | `milestone` | One milestone in a delivery plan. |
+
+Milestone issues are created as **GitHub sub-issues of the requirement issue** they deliver,
+  so the requirement issue shows delivery progress without duplicating the milestone list.
+
+### What Each Issue Contains
+
+A **requirement issue** links to its requirement document, summarizes it in a paragraph,
+  links to the related vision issue, records priority,
+  and points at the delivery plan and the milestone sub-issues that deliver it.
+
+A **milestone issue** links to the delivery plan and names which milestone it tracks,
+  then restates that milestone's `Scope` and `Deliverable` briefly,
+  and turns the milestone's scope into an **acceptance-criteria checklist** that can be ticked off.
+Close it when its PR merges, noting the implementing PR number.
+
+### When Tracking Issues Are Warranted
+
+Create tracking issues when a delivery plan exists —
+  that is, when work spans multiple PRs and the sequencing matters.
+Work small enough to fit in a single PR needs no delivery plan
+  and no milestone issues;
+  a plain issue (or no issue at all, for trivial changes) is enough.
+
+### Requirements, Milestones, and PRs
+
+These are **not** necessarily one-to-one, and conflating them causes trouble:
+
+- A requirement is scoped to be implementable in a single PR
+    (see [../product-requirements/README.md](../product-requirements/README.md)).
+- A milestone also ships as a single PR.
+- But a milestone may deliver *part* of a large requirement,
+    or span *several* small requirements,
+    or deliver infrastructure that no requirement describes on its own
+    (project scaffolding, CI wiring, a contract definition).
+
+When a milestone doesn't map cleanly onto exactly one requirement,
+  say so explicitly in the milestone issue,
+  and link every requirement it touches.
+If a requirement repeatedly needs several milestones to deliver,
+  that is a signal the requirement was sliced too thick — consider splitting it.
+
 ## Referencing Milestones in Code and Docs
 
 Don't hard-code specific milestone identifiers (M2, M3, …) in code, comments, or project docs:

--- a/design/delivery-plans/template.md
+++ b/design/delivery-plans/template.md
@@ -1,0 +1,80 @@
+# [Project Name] Delivery Plan
+
+## Overview
+
+What this plan sequences, and into how many milestones.
+Link to the product requirements it delivers and the engineering design it follows.
+
+State the **main delivery risk** and explain how the milestone ordering addresses it.
+This is the most valuable paragraph in the document:
+  it records *why* the sequence is what it is,
+  which is exactly the reasoning that is otherwise lost.
+
+Call out anything deliberately pushed to a late, optional milestone,
+  and say plainly that the earlier milestones stand on their own without it.
+
+## Delivery Conventions
+
+Conventions that apply to every milestone in this plan.
+Common ones:
+
+- **Each milestone ships as its own merged PR.**
+- **Public docs are built incrementally, alongside code, tests, and CI** — not deferred to the last
+    milestone.
+  Every milestone PR leaves the project's `README.md` accurate for the state of the project
+    *at that point*.
+
+## Milestones
+
+Each milestone gets its own `###` heading, numbered `M1`, `M2`, ….
+Milestones must be **thin vertical slices**:
+  each one delivers something independently usable or testable,
+  not an intermediate state that only makes sense in hindsight.
+A good test is whether the reader could stop after any milestone
+  and still have something worth having.
+
+### M1 — [Short milestone title]
+
+**In scope:**
+
+- The concrete work this milestone includes.
+- Enough detail to bound the scope, but *not* an implementation recipe —
+    the steps inside the PR are left to whoever does the work.
+- Include tests, docs, and CI wiring as explicit scope items where they apply.
+
+**Deliverable:** one or two sentences describing what a user, consumer, or contributor
+  can actually do once this milestone merges.
+Write it from their perspective, not the implementer's.
+
+**Deferred:** what this milestone explicitly does *not* include,
+  particularly anything a reader might otherwise assume is covered.
+
+### M2 — [Short milestone title]
+
+Repeat the `In scope` / `Deliverable` / `Deferred` structure for each milestone.
+
+### M[N] — [Short milestone title] (optional; may not be reached)
+
+Mark genuinely optional milestones as such in the heading,
+  and open the section by saying what makes them optional
+  and confirming that the earlier milestones are fully usable without them.
+Note any prerequisite that would have to be satisfied before the milestone could start
+  (a paid account, an external dependency, a decision that hasn't been made yet).
+
+## Explicitly Deferred (out of scope for this plan)
+
+Work that is deliberately *not* in any milestone, with a brief reason for each.
+This section prevents the plan from being read as an exhaustive roadmap,
+  and it is where **honest deferral** happens:
+  separate work that is required for the feature to function
+  from nice-to-have polish, and be explicit about which this is.
+
+Track anything here that needs to survive as actionable work
+  in a GitHub issue, per [`.claude/rules/github-issues.md`](/.claude/rules/github-issues.md).
+
+## References
+
+- **Product Vision**: [Vision Title](../product-vision/YYYY-MM-DD-short-name.md).
+- **Product Requirements**: [Requirement Title](../product-requirements/YYYY-MM-DD-short-name.md).
+- **Engineering Design**: [Design Title](../engineering-designs/YYYY-MM-DD-short-name.md).
+- **Analyses**: [Analysis Title](../analyses/YYYY-MM-DD-short-name.md).


### PR DESCRIPTION
## Summary

For anyone (human or agent) starting non-trivial work in this repo, the design process was documented but not *navigable*: you had to already know it existed, read six READMEs to find the sequence, and discover by archaeology that delivery plans had no template and that "milestone tracking issues" were never actually specified. This PR makes the process self-serve.

- Adds `.claude/skills/design-process/` — the repo's first agent skill. It routes through analysis → vision → requirements → engineering design → delivery plan, pointing at the authoritative READMEs, templates, and rules rather than restating them.
- Adds `design/delivery-plans/template.md`, the one document type in the workflow that had no template.
- Documents the design-doc ↔ GitHub-issue relationship in `design/delivery-plans/README.md`, with a pointer from `.claude/rules/github-issues.md`.

## Design Process

This PR is process tooling rather than product work, so it adds no vision/requirement/design docs of its own (per the requirement litmus test in `design/product-requirements/README.md`: it affects how developers work on the product, not the product's capabilities for users). It modifies:

- `design/delivery-plans/README.md` — adds the issue-tracking section.
- `design/delivery-plans/template.md` — new.
- `.claude/rules/github-issues.md` — adds a pointer to the above.

## Success Criteria

- [x] **All CI checks pass**: Tests pass, linting succeeds, formatting correct.
- [ ] **Code review recommendations addressed**: All review feedback implemented.
- [x] **No stubbed/incomplete code**: All implementations are complete and tested.
- [x] **No TODO/FIXME without tracking**: All TODOs tracked in GitHub issues with references.
- [x] **Deferred work tracked in GitHub issues**: Any work deferred for future implementation must be tracked in GitHub issues with clear descriptions and acceptance criteria.
- [x] **Follows Engineering Principles**: Code adheres to all `design/engineering-principles/` or has documented (and reasonable) explanations for any divergences.

**For documentation PRs:**

- [x] Markdown formatting follows project guidelines.
- [x] All links verified working.
- [x] Spelling and grammar checked.

## Test Plan

- `MISE_EXPERIMENTAL=1 mise run '//:ci'` — green.
- Verified all 16 relative links in `SKILL.md` resolve, plus the new links in the two modified docs.
- Verified markdown-style compliance (line length, trailing whitespace, trailing newline) on all changed files.
- **Skill discovery**: `claude -p` in this worktree lists `design-process` among available skills.
- **Positive routing test**: asked "I want to add a new feature: a tool that syncs Markdown task lists with Todoist. What should I do first?" — correctly identified it as needing the design process, checked for an existing vision, started at product vision, pointed at the template, proactively flagged that an API-facts analysis should come first, and mentioned tracking issues and one-user-story-per-PR requirement slicing.
- **Negative routing test**: asked about fixing a README typo — correctly skipped the design process entirely and gave the plain PR workflow, marking "Design Process — N/A".

## Context

The issue-tracking conventions documented here were already in use (see #16–#21 for milestone issues, #23 for vision, #24 for requirement) — they were simply never written down, so `.claude/rules/delivery-milestones.md` and `design/delivery-plans/README.md` both referred to "milestone tracking issues" as a source of truth that nothing defined. This writes down the existing practice and resolves the case those docs left implicit, where a milestone doesn't map one-to-one onto a requirement.

This is the first of two related PRs; the second will use this skill to author a design lineage for a `markdown-tasks-sync` project, which doubles as the skill's real-world test.